### PR TITLE
Character sheet header restyling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.7.3
-- UI fix by [HikariNoTsurugi](https://github.com/HikariNoTsurugis)
+- UI fix by [HikariNoTsurugi](https://github.com/HikariNoTsurugi)
 
 ## 0.7.2
 - ゆとシートIIインポートマクロ更新

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ URL
 
 ### 開発サポート
 - [kuouvadis](https://github.com/kuouvadis)
-- [HikariNoTsurugi](https://github.com/HikariNoTsurugis)
+- [HikariNoTsurugi](https://github.com/HikariNoTsurugi)
 
 ## 権利表記
 [MITライセンス](LICENSE.txt)

--- a/css/sw25.css
+++ b/css/sw25.css
@@ -575,8 +575,8 @@ progress.mp-bar::-moz-progress-bar {
 /* Character sheet */
 .sw25 .sheet-header .adventurer-details {
   align-self: flex-start;
-  flex: 0 0 100px;
-  margin-right: var(--spacing-md);
+  flex: 0 0 105px;
+  margin-right: var(--spacing-sm);
 }
 .sw25 .sheet-header .adventurer-details .adventurer-level {
   font-size: 1.6rem;

--- a/css/sw25.css
+++ b/css/sw25.css
@@ -2,12 +2,14 @@
 
 /* Variables */
 :root {
-  --spacing-xxs: .1em;
-  --spacing-xs: .2em;
-  --spacing-sm: .4em;
-  --spacing-md: .8em;
-  --spacing-lg: 1.6em;
-  --spacing-xl: 3.2em;
+  --spacing-xxs: .1rem;
+  --spacing-xs: .2rem;
+  --spacing-sm: .4rem;
+  --spacing-md: .8rem;
+  --spacing-lg: 1.6rem;
+  --spacing-xl: 3.2rem;
+  --color-hp-meter: #6bb338;
+  --color-mp-meter: #08acff;
 }
 
 /* Global styles */
@@ -332,27 +334,60 @@
   font-weight: bold;
 }
 
+hr {
+  border: 0;
+  border-top: 1px solid var(--color-border-dark-1);
+  margin: var(--spacing-xs) 0 0 0;
+}
+progress {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+}
+progress.hp-bar,
+progress.mp-bar {
+  height: 4px;
+  margin: var(--spacing-xs) 0 var(--spacing-sm) 0;
+}
+progress.hp-bar::-webkit-progress-value {
+  background-color: var(--color-hp-meter);
+}
+progress.hp-bar::-moz-progress-bar {
+  background-color: var(--color-hp-meter);
+}
+progress.mp-bar::-webkit-progress-value {
+  background-color: var(--color-mp-meter);
+}
+progress.mp-bar::-moz-progress-bar {
+  background-color: var(--color-mp-meter);
+}
+.nobreak {
+  white-space: nowrap;
+}
+
 
 /* Styles limited to sw25 sheets */
+
+/* General sheet elements */
+.sw25 .adjustable-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sw25 .adjustable-container input {
+  flex: 0 0 2rem;
+  text-align: center;
+}
+.sw25 .adjustable-container .adjustment-button {
+  margin: 0 var(--spacing-xs);
+}
 .sw25 .item-form {
   font-family: "Roboto", sans-serif;
 }
 .sw25 .sheet-header {
   flex: 0 auto;
   overflow: hidden;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  margin-bottom: 10px;
-}
-.sw25 .sheet-header .profile-img {
-  flex: 0 0 100px;
-  height: 100px;
-  margin-right: 10px;
-}
-.sw25 .sheet-header .header-fields {
-  flex: 1;
 }
 .sw25 .sheet-header h1.charname {
   height: 50px;
@@ -535,4 +570,77 @@
 }
 .sw25 .effects .item .effect-controls {
   border: none;
+}
+
+/* Character sheet */
+.sw25 .sheet-header .adventurer-details {
+  align-self: flex-start;
+  flex: 0 0 100px;
+  margin-right: var(--spacing-md);
+}
+.sw25 .sheet-header .adventurer-details .adventurer-level {
+  font-size: 1.6rem;
+  font-weight: bold;
+}
+.sw25 .sheet-header .profile-img {
+  height: 100px;
+  margin: 0;
+}
+.sw25 .sheet-header .header-fields {
+  align-self: flex-start;
+}
+.sw25 .sheet-header .header-fields .character-details {
+  flex: 0 0 300px;
+}
+.sw25 .sheet-header .header-fields .character-details .character-name,
+.sw25 .sheet-header .header-fields .character-details .character-details-secondary,
+.sw25 .sheet-header .header-fields .character-details .character-details-tertiary {
+  margin: 0 var(--spacing-xs);
+}
+.sw25 .sheet-header .header-fields .character-details .character-race {
+  flex: 0 0 60%;
+}
+.sw25 .sheet-header .header-fields .character-details .character-age {
+   flex: 0 0 15%;
+}
+.sw25 .sheet-header .header-fields .character-details .character-gender {
+  flex: 0 0 25%;
+}
+.sw25 .sheet-header .header-fields .character-details .character-rank {
+  flex: 0 0 50%;
+}
+.sw25 .sheet-header .header-fields .character-details .character-fumble {
+  flex: 0 0 25%;
+}
+.sw25 .sheet-header .header-fields .character-details .character-impurity {
+  flex: 0 0 25%;
+}
+.sw25 .sheet-header .header-resources {
+  margin: 0 var(--spacing-xs);
+  min-height: 125px;
+  position: relative;
+}
+.sw25 .sheet-header .header-fields .resources.grid {
+  grid-template-columns: 24px 1fr auto;
+  gap: 0 var(--spacing-xs);
+  margin: 0;
+}
+.sw25 .sheet-header .header-resources label {
+  height: var(--form-field-height);
+  line-height: var(--form-field-height);
+  vertical-align: middle;
+}
+.sw25 .sheet-header .header-resources .current-max-resource {
+  display: inline-block;
+}
+.sw25 .sheet-header .header-resources input {
+  text-align: center;
+  vertical-align: middle;
+}
+.sw25 .sheet-header .header-resources .resources input[type="number"] {
+  width: 2.5rem;
+}
+.sw25 .sheet-header .header-resources .character-resources {
+  position: absolute;
+  bottom: var(--spacing-xs);
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -52,11 +52,10 @@
 
     "Notargetwarn": "No targets selected.",
     "Multitargetwarn": "Multi targets selected.",
-       
+      
+    "CharacterName": "Character Name",
     "Hp": "HP",
     "Mp": "MP",
-    "Hpmod": "Max HP Mod",
-    "Mpmod": "Max MP Mod",
     "Race": "Race",
     "Biography": "Biography",
     "Languages": "Languages",

--- a/lang/en.json
+++ b/lang/en.json
@@ -52,7 +52,7 @@
 
     "Notargetwarn": "No targets selected.",
     "Multitargetwarn": "Multi targets selected.",
-      
+
     "CharacterName": "Character Name",
     "Hp": "HP",
     "Mp": "MP",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -52,11 +52,10 @@
 
     "Notargetwarn": "ターゲットが指定されていません",
     "Multitargetwarn": "ターゲットが複数指定されています",
-            
+    
+    "CharacterName": "キャラクター名",
     "Hp": "HP",
     "Mp": "MP",
-    "Hpmod": "最大HP修正",
-    "Mpmod": "最大MP修正",
     "Race": "種族",
     "Biography": "容姿・経歴・その他メモ",
     "Languages": "言語",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -52,7 +52,7 @@
 
     "Notargetwarn": "ターゲットが指定されていません",
     "Multitargetwarn": "ターゲットが複数指定されています",
-    
+
     "CharacterName": "キャラクター名",
     "Hp": "HP",
     "Mp": "MP",

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -103,7 +103,6 @@
             <input id="{{_id}}grace" type="checkbox" name="system.attributes.grace" {{checked system.attributes.grace}} data-dtype="Boolean"/>
           </div>
         </div>
-        
       </div>
     </div>
   </header>
@@ -585,15 +584,8 @@
         </div>
         <div class="flexcol grid-span-3">
           <div class="flexrow grid grid-6col nogapmargin">
-            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Age"}}</b><br><input type="text" name="system.attributes.age" value="{{system.attributes.age}}" data-dtype="Number"/></span> --}}
-            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Gender"}}</b><br><input type="text" name="system.attributes.gender" value="{{system.attributes.gender}}" data-dtype="String"/></span> --}}
-            {{!-- <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Race"}}</b><br><input type="text" name="system.race" value="{{system.race}}" data-dtype="String"/></span> --}}
             <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Born"}}</b><br><input type="text" name="system.attributes.born" value="{{system.attributes.born}}" data-dtype="String"/></span>
             <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Faith"}}</b><br><input type="text" name="system.attributes.faith" value="{{system.attributes.faith}}" data-dtype="String"/></span>
-            {{!-- <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Honer.Rank"}}</b><br><input type="text" name="system.attributes.honer.rank" value="{{system.attributes.honer.rank}}" data-dtype="String"/></span> --}}
-            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Honer.Label"}}</b><br><input type="text" name="system.attributes.honer.value" value="{{system.attributes.honer.value}}" data-dtype="Number"/></span> --}}
-            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Impurity"}}</b><br><input type="text" name="system.attributes.impurity" value="{{system.attributes.impurity}}" data-dtype="Number"/></span> --}}
-            {{!-- <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Exp"}}</b><br><input type="text" name="system.attributes.totalexp" value="{{system.attributes.totalexp}}" data-dtype="Number"/></span> --}}
           </div>
         </div>
       </div>

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -2,60 +2,108 @@
 
   {{!-- Sheet Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
-    <div class="header-fields">
-      <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="Name"/></h1>
-      <div class="resources grid grid-4col">
-        <div class="resource flexcol flex-between flex-group-center gap-s">
-          <div class="flexrow align-bottom">
-            <label for="system.hp.value" class="resource-label-l">{{localize "SW25.Hp"}}</label>
-            <input class="resource-label-l" type="text" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number"/>
-            <span class="align-bottom">/{{system.hp.max}}</span>
+    <div class="adventurer-details">
+      <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+      <div class="flexcol textalign-center">
+        <label for="system.attributes.advlevel.value" class="resource-label">{{localize "SW25.Attributes.Advlevel"}}</label>
+        <span class="adventurer-level">{{system.attributes.advlevel.value}}</span>
+      </div>
+    </div>
+    <div class="header-fields flexrow">
+      <div class="character-details">
+        <hr>
+        <div class="character-name">
+          <label for="{{_id}}name" class="resource-label">{{localize "SW25.CharacterName"}}</label>
+          <input id="{{_id}}name" name="name" type="text" value="{{actor.name}}" placeholder="Name"/>
+        </div>
+        <hr>
+        <div class="character-details-secondary flexrow">
+          <div class="character-race">
+            <label for="{{_id}}race" class="resource-label">{{localize "SW25.Race"}}</label> 
+            <input id="{{id}}race" type="text" name="system.race" value="{{system.race}}" data-dtype="String"/>
           </div>
-          <div class="flexrow align-bottom">
-            <label for="system.mp.value" class="resource-label-l">{{localize "SW25.Mp"}}</label>
-            <input class="resource-label-l" type="text" name="system.mp.value" value="{{system.mp.value}}" data-dtype="Number"/>
-            <span class="align-bottom">/{{system.mp.max}}</span>
+          <div class="character-age textalign-center">
+            <label for="{{_id}}age" class="resource-label">{{localize "SW25.Attributes.Age"}}</label>
+            <input id="{{_id}}age" type="number" name="system.attributes.age" value="{{system.attributes.age}}" data-dtype="Number"/>
           </div>
-          <div class="flexrow flex-group-center">
-            <label for="system.attributes.fumble" class="resource-label-s align-right">{{localize "SW25.Attributes.Fumble"}}:</label>
-            <div class='input flexrow flex-group-center' style="flex: 1 0 20px;">
+          <div class="character-gender textalign-center">
+            <label for="{{_id}}gender" class="resource-label">{{localize "SW25.Attributes.Gender"}}</label>
+            <input id="{{_id}}gender" type="text" name="system.attributes.gender" value="{{system.attributes.gender}}" data-dtype="String"/>
+          </div>
+        </div>
+        <hr>
+        <div class="character-details-tertiary flexrow">
+          <div class="character-rank">
+            <label for="{{_id}}rank" class="resource-label">{{localize "SW25.Attributes.Honer.Rank"}}</label>
+            <input id="{{_id}}rank" type="text" name="system.attributes.honer.rank" value="{{system.attributes.honer.rank}}" data-dtype="String"/>
+          </div>
+          <div class="character-fumble textalign-center">
+            <label for="{{_id}}fumble" class="resource-label">{{localize "SW25.Attributes.Fumble"}}</label>
+            <div class="adjustable-container">
               <a class="adjustment-button" data-action="decrease" data-property="system.attributes.fumble">
                 <i class="fas fa-minus"></i>
               </a>
-              <input type="number" name="system.attributes.fumble" value="{{system.attributes.fumble}}" data-dtype="Number"/>
+              <input id="{{_id}}fumble" type="number" name="system.attributes.fumble" value="{{system.attributes.fumble}}" data-dtype="Number"/>
               <a class="adjustment-button" data-action="increase" data-property="system.attributes.fumble">
                 <i class="fas fa-plus"></i>
               </a>
             </div>
           </div>
-        </div>
-
-        <div class="resource flexcol flex-between flex-group-center">
-          <label for="system.attributes.advlevel.value" class="resource-label">{{localize "SW25.Attributes.Advlevel"}}</label>
-          <div class="resource-content flexrow flex-center flex-between">
-            <span class="resource-label-l">{{system.attributes.advlevel.value}}</span>
-          </div>
-          <div class="resource-content flexrow flex-group-right">
-            <label for="system.attributes.grace" class="resource-label-s">{{localize "SW25.Attributes.Grace"}}:</label>
-            <span><input type="checkbox" name="system.attributes.grace" data-dtype="Boolean" {{#if system.attributes.grace}} checked {{/if}}/></span>
-          </div>
-        </div>
-
-        <div class="flexcol flex-between grid-span-2">
-          <div class="flexrow flex-between">
-            <span>{{localize "SW25.Attributes.Age"}}: <b>{{system.attributes.age}}</b></span>
-            <span>{{localize "SW25.Attributes.Gender"}}: <b>{{system.attributes.gender}}</b></span>
-            <span>{{localize "SW25.Attributes.Impurity"}}: <b>{{system.attributes.impurity}}</b></span>
-          </div>
-          <div class="flexrow flex-left">
-            <span>{{localize "SW25.Race"}}: <b>{{system.race}}</b></span>
-          </div>
-          <div class="flexrow flex-left">
-            <span>{{localize "SW25.Attributes.Honer.Rank"}}: <b>{{system.attributes.honer.rank}}</b></span>
+          <div class="character-impurity textalign-center">
+            <label for="{{_id}}impurity" class="resource-label">{{localize "SW25.Attributes.Impurity"}}</label>
+            <div class="adjustable-container">
+              <a class="adjustment-button" data-action="decrease" data-property="system.attributes.impurity">
+                <i class="fas fa-minus"></i>
+              </a>
+              <input id="{{_id}}impurity" type="number" name="system.attributes.impurity" value="{{system.attributes.impurity}}" data-dtype="Number"/>
+              <a class="adjustment-button" data-action="increase" data-property="system.attributes.impurity">
+                <i class="fas fa-plus"></i>
+              </a>
+            </div>
           </div>
         </div>
-
+        <hr>
+      </div>
+      <div class="header-resources">
+        <div class="resources grid grid-3col">
+          <label for="{{_id}}hp" class="resource-label">{{localize "SW25.Hp"}}: </label>
+          <div class="current-max-resource nobreak">
+            <input id="{{_id}}hp" type="number" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number"/>
+            /
+            <span>{{system.hp.max}}</span>
+          </div>
+          <div class="nobreak">
+            <label for="{{_id}}hpmod" class="resource-label">{{localize "SW25.Modifier"}}: </label>
+            <input id="{{_id}}hpmod" type="number" name="system.hp.hpmod" value="{{system.hp.hpmod}}" data-dtype="Number"/>
+          </div>
+          <progress class="hp-bar grid-span-3" value="{{system.hp.value}}" max="{{system.hp.max}}"></progress>
+          <label for="{{_id}}mp" class="resource-label">{{localize "SW25.Mp"}}: </label>
+          <div class="current-max-resource nobreak">
+            <input id="{{_id}}mp" type="number" name="system.mp.value" value="{{system.mp.value}}" data-dtype="Number"/>
+            /
+            <span>{{system.mp.max}}</span>
+          </div>
+          <div class="nobreak">
+            <label for="{{_id}}mpmod" class="resource-label">{{localize "SW25.Modifier"}}: </label>
+            <input id="{{_id}}mpmod" type="number" name="system.mp.mpmod" value="{{system.mp.mpmod}}" data-dtype="Number"/>
+          </div>
+          <progress class="mp-bar grid-span-3" value="{{system.mp.value}}" max="{{system.mp.max}}"></progress>
+        </div>
+        <div class="character-resources flexrow textalign-center">
+          <div class="character-honor">
+            <label for="{{_id}}honor" class="resource-label">{{localize "SW25.Attributes.Honer.Label"}}</label>
+            <input id="{{_id}}honor" type="number" name="system.attributes.honer.value" value="{{system.attributes.honer.value}}" data-dtype="Number"/>
+          </div>
+          <div class="character-experience">
+            <label for="{{_id}}exp" class="resource-label">{{localize "SW25.Attributes.Exp"}}</label>
+            <input id="{{_id}}exp" type="number" name="system.attributes.totalexp" value="{{system.attributes.totalexp}}" data-dtype="Number"/>
+          </div>
+          <div class="character-grace">
+            <label for="{{_id}}grace" class="resource-label">{{localize "SW25.Attributes.Grace"}}</label> <br>
+            <input id="{{_id}}grace" type="checkbox" name="system.attributes.grace" {{checked system.attributes.grace}} data-dtype="Boolean"/>
+          </div>
+        </div>
+        
       </div>
     </div>
   </header>
@@ -111,11 +159,7 @@
         </aside>
         <section class="main grid-span-3">
           <div class="grid grid-3col nogapmargin">
-            <div class="flexcol nogapmargin">
-              <span class="resource-label-s" style="text-align: center;">{{localize "SW25.Hpmod"}} <input style="max-width: calc(35% - 7px); max-height: 80%;" type="text" name="system.hp.hpmod" value="{{system.hp.hpmod}}" data-dtype="Number"/></span>
-              <span class="resource-label-s" style="text-align: center;">{{localize "SW25.Mpmod"}} <input style="max-width: calc(35% - 7px); max-height: 80%;" type="text" name="system.mp.mpmod" value="{{system.mp.mpmod}}" data-dtype="Number"/></span>
-            </div>
-            <div class="grid-span-2 flex-group-right" style="display: flex; align-items: flex-end;">
+            <div class="grid-span-3 flex-group-right" style="display: flex; align-items: flex-end;">
               {{localize "SW25.Attributes.Exp"}} [ {{localize "SW25.Attributes.Useexp"}}: {{#if (gt system.attributes.useexp system.attributes.totalexp)}}<span class="warning-text">{{/if}}{{system.attributes.useexp}}{{#if (gt system.attributes.useexp system.attributes.totalexp)}}</span>{{/if}}<span> / {{localize "SW25.Attributes.Totalexp"}}: {{system.attributes.totalexp}} ]</span>
             </div>
           </div>
@@ -541,15 +585,15 @@
         </div>
         <div class="flexcol grid-span-3">
           <div class="flexrow grid grid-6col nogapmargin">
-            <span style="text-align: center;"><b>{{localize "SW25.Attributes.Age"}}</b><br><input type="text" name="system.attributes.age" value="{{system.attributes.age}}" data-dtype="Number"/></span>
-            <span style="text-align: center;"><b>{{localize "SW25.Attributes.Gender"}}</b><br><input type="text" name="system.attributes.gender" value="{{system.attributes.gender}}" data-dtype="String"/></span>
-            <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Race"}}</b><br><input type="text" name="system.race" value="{{system.race}}" data-dtype="String"/></span>
+            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Age"}}</b><br><input type="text" name="system.attributes.age" value="{{system.attributes.age}}" data-dtype="Number"/></span> --}}
+            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Gender"}}</b><br><input type="text" name="system.attributes.gender" value="{{system.attributes.gender}}" data-dtype="String"/></span> --}}
+            {{!-- <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Race"}}</b><br><input type="text" name="system.race" value="{{system.race}}" data-dtype="String"/></span> --}}
             <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Born"}}</b><br><input type="text" name="system.attributes.born" value="{{system.attributes.born}}" data-dtype="String"/></span>
             <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Faith"}}</b><br><input type="text" name="system.attributes.faith" value="{{system.attributes.faith}}" data-dtype="String"/></span>
-            <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Honer.Rank"}}</b><br><input type="text" name="system.attributes.honer.rank" value="{{system.attributes.honer.rank}}" data-dtype="String"/></span>
-            <span style="text-align: center;"><b>{{localize "SW25.Attributes.Honer.Label"}}</b><br><input type="text" name="system.attributes.honer.value" value="{{system.attributes.honer.value}}" data-dtype="Number"/></span>
-            <span style="text-align: center;"><b>{{localize "SW25.Attributes.Impurity"}}</b><br><input type="text" name="system.attributes.impurity" value="{{system.attributes.impurity}}" data-dtype="Number"/></span>
-            <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Exp"}}</b><br><input type="text" name="system.attributes.totalexp" value="{{system.attributes.totalexp}}" data-dtype="Number"/></span>
+            {{!-- <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Honer.Rank"}}</b><br><input type="text" name="system.attributes.honer.rank" value="{{system.attributes.honer.rank}}" data-dtype="String"/></span> --}}
+            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Honer.Label"}}</b><br><input type="text" name="system.attributes.honer.value" value="{{system.attributes.honer.value}}" data-dtype="Number"/></span> --}}
+            {{!-- <span style="text-align: center;"><b>{{localize "SW25.Attributes.Impurity"}}</b><br><input type="text" name="system.attributes.impurity" value="{{system.attributes.impurity}}" data-dtype="Number"/></span> --}}
+            {{!-- <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Attributes.Exp"}}</b><br><input type="text" name="system.attributes.totalexp" value="{{system.attributes.totalexp}}" data-dtype="Number"/></span> --}}
           </div>
         </div>
       </div>

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -2,16 +2,16 @@
 
   {{!-- Sheet Header --}}
   <header class="sheet-header">
-    <div class="adventurer-details">
+    <div class="adventurer-details textalign-center">
       <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
-      <div class="flexcol textalign-center">
-        <label for="system.attributes.advlevel.value" class="resource-label">{{localize "SW25.Attributes.Advlevel"}}</label>
+      <div class="flexcol">
+        <label for="system.attributes.advlevel.value" class="resource-label nobreak">{{localize "SW25.Attributes.Advlevel"}}</label>
         <span class="adventurer-level">{{system.attributes.advlevel.value}}</span>
       </div>
     </div>
     <div class="header-fields flexrow">
       <div class="character-details">
-        <hr>
+        <hr class="nogapmargin">
         <div class="character-name">
           <label for="{{_id}}name" class="resource-label">{{localize "SW25.CharacterName"}}</label>
           <input id="{{_id}}name" name="name" type="text" value="{{actor.name}}" placeholder="Name"/>


### PR DESCRIPTION
Restyle and change layout of character sheet header to better match physical character sheets.
Add similar functionality for updating "Soulscar"/"穢れ" as "Fumble"/"1ゾロ"
Move the following inputs to header:
- Max HP/MP Mod (最大HP修正/最大MP修正 )
- Age (年齢)
- Gender (性別)
- Race (種族)
- Rank (ランク)
- Rep (名誉点)
- EXP (総計)

Before (ja)
![image](https://github.com/jeannjeann/sw25-fvtt/assets/4213041/ccee96bc-9d22-4b15-adb4-951ee601a70e)
After (ja)
![image](https://github.com/jeannjeann/sw25-fvtt/assets/4213041/3e2181dd-af7c-47b4-a95c-9bf6fb8cab90)
Before (en)
![image](https://github.com/jeannjeann/sw25-fvtt/assets/4213041/2c92a1c1-b318-4d7b-b983-f0280261d59b)
After (en)
![image](https://github.com/jeannjeann/sw25-fvtt/assets/4213041/5e037a07-6832-4046-ba44-a986ec3f3d06)
