### PR TITLE
ゆとシートⅡインポートマクロの機能追加

### DIFF
--- a/macro/yt2import.js
+++ b/macro/yt2import.js
@@ -12,10 +12,10 @@ async function yt2import() {
       <p><input type="file" id="json-file-input" accept=".json" style="width: 100%;" /></p>
       <p></p>
       <p><b>魔物インポートオプション</b></p>
-      <p><input id="abilist" type="checkbox" data-dtype="Boolean" checked/><label for="abilist">魔物能力一覧アイテムを作成</label></p>
-      <p><input id="abidesc" type="checkbox" data-dtype="Boolean"/><label for="abilist">魔物能力一覧を説明タブに展開</label></p>
-      <p><input id="monabi" type="checkbox" data-dtype="Boolean"/><label for="monabi">魔物能力の個別アイテムを作成</label></p>
-      <p><input id="allattack" type="checkbox" data-dtype="Boolean"/><label for="allattack">多部位魔物：全部位分の攻撃を作成</label></p>
+      <p><input id="abilist" type="checkbox" data-dtype="Boolean"/><label for="abilist">魔物能力一覧アイテムを作成</label></p>
+      <p><input id="abidesc" type="checkbox" data-dtype="Boolean" checked/><label for="abilist">魔物能力一覧を説明タブに展開</label></p>
+      <p><input id="monabi" type="checkbox" data-dtype="Boolean" checked/><label for="monabi">魔物能力の個別アイテムを作成</label></p>
+      <p><input id="allattack" type="checkbox" data-dtype="Boolean" checked/><label for="allattack">多部位魔物：全部位分の攻撃を作成</label></p>
       <p><input id="usefix" type="checkbox" data-dtype="Boolean" checked/><label for="usefix">魔物能力で固定値を使用</label></p>
     `;
 
@@ -91,10 +91,11 @@ async function yt2import() {
           },
         ];
         let resourceList = [];
-        let dodgeList = [0, "-"];
-        let dodgeskill = ["ファイター", "グラップラー","フェンサー","バトルダンサー"];
-        let wizardList = [0, "-"];
-        let wzskill = ["ソーサラー", "コンジャラー"];
+        let dodgeList = ["ファイター", "グラップラー","フェンサー","バトルダンサー"];
+        let dodgeskill = [0, "-"];
+        let shooterLv = 0;
+        let wizardList = ["ソーサラー", "コンジャラー"];
+        let wzskill = [0, "-"];
         let initiative = [0, "-", "-"];
         let initList = ["スカウト", "ウォーリーダー"];
         let mknowledge = [0, "-", "-"];
@@ -167,6 +168,9 @@ async function yt2import() {
               dodgeskill[0] = parseInt(skill[i].level);
               dodgeskill[1] = skill[i].name;
             }
+          }
+          if ( skill[i].name == "シューター") {
+            shooterLv = parseInt(skill[i].level);
           }
           if (wizardList.includes(skill[i].name)) {
             if (wzskill[0] < parseInt(skill[i].level)) {
@@ -844,6 +848,12 @@ async function yt2import() {
           );
           if (combatability[i] == "終律増強") {
             metafinalsong = true;
+          }
+          if (combatability[i] == "射手の体術") {
+            if (dodgeskill[0] < shooterLv) {
+              dodgeskill[0] = shooterLv;
+              dodgeskill[1] = "シューター";
+            }
           }
           if (!matchItem) {
             matchItem = await findEntryInCompendium("Item", combatability[i]);

--- a/macro/yt2import.js
+++ b/macro/yt2import.js
@@ -5,6 +5,7 @@ async function yt2import() {
   let abidesc = false;
   let monabi = false;
   let allattack = false;
+  let usefix = false;
   let fileInput = await new Promise((resolve) => {
     let dialogContent = `
       <p>JSONファイル(ゆとシートII出力)を選択してください:</p>
@@ -14,7 +15,8 @@ async function yt2import() {
       <p><input id="abilist" type="checkbox" data-dtype="Boolean" checked/><label for="abilist">魔物能力一覧アイテムを作成</label></p>
       <p><input id="abidesc" type="checkbox" data-dtype="Boolean"/><label for="abilist">魔物能力一覧を説明タブに展開</label></p>
       <p><input id="monabi" type="checkbox" data-dtype="Boolean"/><label for="monabi">魔物能力の個別アイテムを作成</label></p>
-      <p><input id="allattack" type="checkbox" data-dtype="Boolean"/><label for="monabi">多部位魔物：全部位分の攻撃を作成</label></p>
+      <p><input id="allattack" type="checkbox" data-dtype="Boolean"/><label for="allattack">多部位魔物：全部位分の攻撃を作成</label></p>
+      <p><input id="usefix" type="checkbox" data-dtype="Boolean" checked/><label for="usefix">魔物能力で固定値を使用</label></p>
     `;
 
     new Dialog({
@@ -30,6 +32,7 @@ async function yt2import() {
             abidesc = html.find("#abidesc")[0].checked;
             monabi = html.find("#monabi")[0].checked;
             allattack = html.find("#allattack")[0].checked;
+            usefix = html.find("#usefix")[0].checked;
             if (!file) {
               ui.notifications.warn("ファイルが選択されていません。");
               return;
@@ -60,63 +63,11 @@ async function yt2import() {
       // PC
       let biography = decodeHTML(data.freeNote);
 
+      let hitweapon = "";
+      if (data.weapon1Name)
+        hitweapon = data.weapon1Name;
+
       if (!data.monsterName) {
-        actorData = {
-          name: data.characterName,
-          type: "character",
-          system: {
-            abilities: {
-              dex: {
-                racevalue: Number(data.sttBaseTec),
-                valuebase: Number(data.sttBaseA),
-                valuegrowth: Number(data.sttGrowA),
-                valuemodify: Number(data.sttAddA),
-              },
-              agi: {
-                valuebase: Number(data.sttBaseB),
-                valuegrowth: Number(data.sttGrowB),
-                valuemodify: Number(data.sttAddB),
-              },
-              str: {
-                racevalue: Number(data.sttBasePhy),
-                valuebase: Number(data.sttBaseC),
-                valuegrowth: Number(data.sttGrowC),
-                valuemodify: Number(data.sttAddC),
-              },
-              vit: {
-                valuebase: Number(data.sttBaseD),
-                valuegrowth: Number(data.sttGrowD),
-                valuemodify: Number(data.sttAddD),
-              },
-              int: {
-                racevalue: Number(data.sttBaseSpi),
-                valuebase: Number(data.sttBaseE),
-                valuegrowth: Number(data.sttGrowE),
-                valuemodify: Number(data.sttAddE),
-              },
-              mnd: {
-                valuebase: Number(data.sttBaseF),
-                valuegrowth: Number(data.sttGrowF),
-                valuemodify: Number(data.sttAddF),
-              },
-            },
-            money: data.moneyTotal,
-            race: data.race,
-            biography: biography,
-            attributes: {
-              age: data.age,
-              gender: data.gender,
-              born: data.birth,
-              faith: data.faith,
-              honer: {
-                rank: data.rank,
-                value: data.honor,
-              },
-              impurity: data.sin,
-              totalexp: data.expTotal,
-            },
-          },
-        };
         itemData = [
           {
             name: "生命抵抗力",
@@ -140,6 +91,10 @@ async function yt2import() {
           },
         ];
         let resourceList = [];
+        let dodgeList = [0, "-"];
+        let dodgeskill = ["ファイター", "グラップラー","フェンサー","バトルダンサー"];
+        let wizardList = [0, "-"];
+        let wzskill = ["ソーサラー", "コンジャラー"];
         let initiative = [0, "-", "-"];
         let initList = ["スカウト", "ウォーリーダー"];
         let mknowledge = [0, "-", "-"];
@@ -207,6 +162,18 @@ async function yt2import() {
           }
 
           // 判定技能
+          if (dodgeList.includes(skill[i].name)) {
+            if (dodgeskill[0] < parseInt(skill[i].level)) {
+              dodgeskill[0] = parseInt(skill[i].level);
+              dodgeskill[1] = skill[i].name;
+            }
+          }
+          if (wizardList.includes(skill[i].name)) {
+            if (wzskill[0] < parseInt(skill[i].level)) {
+              wzskill[0] = parseInt(skill[i].level);
+              wzskill[1] = skill[i].name;
+            }
+          }
           if (initList.includes(skill[i].name)) {
             if (initiative[0] < parseInt(skill[i].level)) {
               initiative[0] = parseInt(skill[i].level);
@@ -1078,6 +1045,47 @@ async function yt2import() {
             });
           }
         }
+        
+        // マテリアルカード追加
+        let materialE = ["Red","Gre","Bla","Whi","Gol"];
+        let materialJ = ["赤","緑","黒","白","金"];
+        let materialR = ["B","A","S","SS"];
+        for (let i = 0; i < materialE.length; i++) {
+          for (const crank of materialR) {
+            if(data["card" + materialE[i] + crank]){
+               let cardName = "マテリアルカード（"
+                 + materialJ[i]
+                 + crank
+                 + "）";
+               let quantity = parseInt(data["card" + materialE[i] + crank]);
+
+               let matchItem = game.items.find(
+                 (item) => item.name === cardName
+               );
+               if (!matchItem) {
+                 matchItem = await findEntryInCompendium(
+                   "Item",
+                   cardName
+                 );
+               }
+               if (matchItem) {
+                 let setData = duplicate(matchItem);
+                 setData.system.quantity = quantity;
+                 itemData.push(setData);
+               } else {
+                 itemData.push({
+                   name: data[`craftEnhance${i}`],
+                   type: "item",
+                   system: {
+                     quantity: quantity,
+                     description: "",
+                   },
+                 });
+               }
+            }
+          }
+        }
+        
         // リソース追加
         for (const resource of resourceList) {
           let matchItem = game.items.find((item) => item.name === resource);
@@ -1098,6 +1106,77 @@ async function yt2import() {
             });
           }
         }
+
+        actorData = {
+          name: data.characterName,
+          type: "character",
+          system: {
+            abilities: {
+              dex: {
+                racevalue: Number(data.sttBaseTec),
+                valuebase: Number(data.sttBaseA),
+                valuegrowth: Number(data.sttGrowA),
+                valuemodify: Number(data.sttAddA),
+              },
+              agi: {
+                valuebase: Number(data.sttBaseB),
+                valuegrowth: Number(data.sttGrowB),
+                valuemodify: Number(data.sttAddB),
+              },
+              str: {
+                racevalue: Number(data.sttBasePhy),
+                valuebase: Number(data.sttBaseC),
+                valuegrowth: Number(data.sttGrowC),
+                valuemodify: Number(data.sttAddC),
+              },
+              vit: {
+                valuebase: Number(data.sttBaseD),
+                valuegrowth: Number(data.sttGrowD),
+                valuemodify: Number(data.sttAddD),
+              },
+              int: {
+                racevalue: Number(data.sttBaseSpi),
+                valuebase: Number(data.sttBaseE),
+                valuegrowth: Number(data.sttGrowE),
+                valuemodify: Number(data.sttAddE),
+              },
+              mnd: {
+                valuebase: Number(data.sttBaseF),
+                valuegrowth: Number(data.sttGrowF),
+                valuemodify: Number(data.sttAddF),
+              },
+            },
+            money: data.moneyTotal,
+            race: data.race,
+            biography: biography,
+            attributes: {
+              age: data.age,
+              gender: data.gender,
+              born: data.birth,
+              faith: data.faith,
+              honer: {
+                rank: data.rank,
+                value: data.honor,
+              },
+              impurity: data.sin,
+              totalexp: data.expTotal,
+            },
+            hitweapon: hitweapon,
+            attackskill : data.weapon1Class,
+            dodgeskill: dodgeskill[1],
+            herbskill: "レンジャー",
+            potionskill: "レンジャー",
+            repairskill: "ライダー",
+            scskill: "ソーサラー",
+            cnskill: "コンジャラー",
+            wzskill: wzskill[1],
+            prskill: "プリースト",
+            mtskill: "マギテック",
+            frskill: "フェアリーテイマー",
+            drskill: "ドルイド",
+            dmskill: "デーモンルーラー",
+          },
+        };
 
         createActor(actorData, itemData);
       }
@@ -1121,15 +1200,9 @@ async function yt2import() {
         }
         let biography;
         let feature = data.skills.replace(/&lt;br&gt;/g, "<br>");
-        if (abidesc)
-          biography =
-            convertHtmlFromFeature(feature) +
-            "<br><h3><b>解説</b></h3>" +
-            decodeHTML(data.description);
-        else biography = "<h3><b>解説</b></h3>" + decodeHTML(data.description);
 
-        let actorNum = parseInt(data.partsNum, 10)
-          ? parseInt(data.partsNum, 10)
+        let actorNum = parseInt(data.statusNum, 10)
+          ? parseInt(data.statusNum, 10)
           : 1;
 
         let mountLv = parseInt(data.lvMin)
@@ -1152,18 +1225,20 @@ async function yt2import() {
               description: "",
               usedice1: true,
               label1: "生命",
-              checkbasemod1: vitResist,
-              usefix1: true,
+              checkbasemod1: eval(vitResist),
+              usefix1: usefix,
               applycheck1: false,
               usedice2: true,
               label2: "精神",
-              checkbasemod2: mndResist,
-              usefix2: true,
+              checkbasemod2: eval(mndResist),
+              usefix2: usefix,
               applycheck2: false,
             },
           },
         ];
 
+
+        let partsList = [];
         for (var i = 1; i <= actorNum; i++) {
           let mountLv = parseInt(data.lvMin)
             ? parseInt(data.lv) - parseInt(data.lvMin)
@@ -1182,26 +1257,41 @@ async function yt2import() {
                 description: "",
                 usedice1: true,
                 label1: "命中",
-                checkbasemod1: data["status" + access + "Accuracy"],
-                usefix1: true,
+                checkbasemod1: eval(data["status" + access + "Accuracy"]),
+                usefix1: usefix,
                 applycheck1: false,
                 usedice2: true,
                 label2: "打撃",
                 checkbasemod2: itemDamage,
-                usefix2: false,
+                usefix2: usefix,
                 applycheck2: true,
                 usedice3: true,
                 label3: "回避",
-                checkbasemod3: data["status" + access + "Evasion"],
-                usefix3: true,
+                checkbasemod3: eval(data["status" + access + "Evasion"]),
+                usefix3: usefix,
                 applycheck3: false,
               },
             });
           }
+          if (abidesc)
+            partsList.push([
+             data["status" + i + "Style"],
+             eval(data["status" + access + "Accuracy"]),
+             data["status" + access + "Damage"],
+             eval(data["status" + access + "Evasion"]),
+             eval(data["status" + access + "Defense"]),
+             eval(data["status" + access + "Hp"]),
+             eval(data["status" + access + "Mp"]),
+            ]);
         }
 
+        if (abidesc)
+          biography = getBiography(feature, data.description, partsList);
+        else biography = "<h3><b>解説</b></h3>" + decodeHTML(data.description);
+
+
         if (monabi) {
-          abilityList = analysisFeature(feature);
+          abilityList = analysisFeature(feature, usefix);
           for (const val of abilityList) {
             itemData.push(val);
           }
@@ -1225,20 +1315,21 @@ async function yt2import() {
             ? parseInt(data.lv) - parseInt(data.lvMin)
             : 0;
           let access = mountLv == 0 ? i : i + "-" + (mountLv + 1);
+          
           actorData = {
             name: actName,
             type: "monster",
             system: {
               hp: {
-                value: data["status" + access + "Hp"],
+                value: eval(data["status" + access + "Hp"]),
               },
               mp: {
-                value: data["status" + access + "Mp"],
+                value: eval(data["status" + access + "Mp"]),
               },
               monlevel: data.lv,
-              hpbase: data["status" + access + "Hp"],
-              mpbase: data["status" + access + "Mp"],
-              ppbase: data["status" + access + "Defense"],
+              hpbase: eval(data["status" + access + "Hp"]),
+              mpbase: eval(data["status" + access + "Mp"]),
+              ppbase: eval(data["status" + access + "Defense"]),
               type: data.taxa,
               intelligence: data.intellect,
               perception: data.perception,
@@ -1313,7 +1404,7 @@ function createActor(actorData, itemData) {
 }
 
 // 魔物特殊能力解析
-function analysisFeature(feature) {
+function analysisFeature(feature, usefix) {
   const array = feature.split("<br>");
   var parts = "";
   const patternParts = /^●(.*)$/g;
@@ -1345,7 +1436,7 @@ function analysisFeature(feature) {
     "",
     "",
     false,
-    false,
+    usefix,
     false,
     false,
     false,
@@ -1386,7 +1477,7 @@ function analysisFeature(feature) {
         "",
         "",
         false,
-        false,
+        usefix,
         false,
         false,
         false,
@@ -1448,7 +1539,7 @@ function analysisFeature(feature) {
         "",
         "",
         false,
-        false,
+        usefix,
         false,
         false,
         false,
@@ -1558,6 +1649,47 @@ function convertHtmlFromFeature(feature) {
   }
   ret = ret + "</section>";
   return ret;
+}
+
+function getBiography(feature, description, partsList){
+   let biography = `
+      <table class="status">
+        <thead>
+          <tr>
+            <th>攻撃方法（部位）
+            <th>命中力
+            <th>打撃点
+            <th>回避力
+            <th>防護点
+            <th>ＨＰ
+            <th>ＭＰ
+        </thead>
+        <tbody>
+   `;
+   for ( const parts of partsList){
+     acc = parts[1] + 7;
+     eva = parts[3] + 7;
+     biography += `
+            <tr>
+              <td class="pt-item">${parts[0]}
+              <td class="pt-item">${parts[1]} (${acc})
+              <td class="pt-item">${parts[2]}
+              <td class="pt-item">${parts[3]} (${eva})
+              <td class="pt-item">${parts[4]}
+              <td class="pt-item">${parts[5]}
+              <td class="pt-item">${parts[6]}
+     `;
+   }
+   biography += `
+        </tbody>
+      </table>
+   `;
+
+   biography +=
+     convertHtmlFromFeature(feature) +
+     "<br><h3><b>解説</b></h3>" +
+     decodeHTML(description);
+   return biography;
 }
 
 // 全角半角変換関数

--- a/macro/yt2import.js
+++ b/macro/yt2import.js
@@ -64,8 +64,7 @@ async function yt2import() {
       let biography = decodeHTML(data.freeNote);
 
       let hitweapon = "";
-      if (data.weapon1Name)
-        hitweapon = data.weapon1Name;
+      if (data.weapon1Name) hitweapon = data.weapon1Name;
 
       if (!data.monsterName) {
         itemData = [
@@ -91,7 +90,12 @@ async function yt2import() {
           },
         ];
         let resourceList = [];
-        let dodgeList = ["ファイター", "グラップラー","フェンサー","バトルダンサー"];
+        let dodgeList = [
+          "ファイター",
+          "グラップラー",
+          "フェンサー",
+          "バトルダンサー",
+        ];
         let dodgeskill = [0, "-"];
         let shooterLv = 0;
         let wizardList = ["ソーサラー", "コンジャラー"];
@@ -169,7 +173,7 @@ async function yt2import() {
               dodgeskill[1] = skill[i].name;
             }
           }
-          if ( skill[i].name == "シューター") {
+          if (skill[i].name == "シューター") {
             shooterLv = parseInt(skill[i].level);
           }
           if (wizardList.includes(skill[i].name)) {
@@ -743,7 +747,7 @@ async function yt2import() {
         ];
         for (let i = 0; i < accessorypart.length; i++) {
           let addAcc = 0;
-          for (let j = 0; j <= addAcc ; j++) {
+          for (let j = 0; j <= addAcc; j++) {
             let underbar = "";
             for (let k = 0; k < j; k++) {
               underbar += "_";
@@ -752,7 +756,7 @@ async function yt2import() {
             let accown = "accessory" + accessorypart[i] + underbar + "Own";
             let accnote = "accessory" + accessorypart[i] + underbar + "Note";
             let accadd = "accessory" + accessorypart[i] + underbar + "Add";
-            
+
             let accpart;
             switch (accessorypart[i]) {
               case "Head":
@@ -789,11 +793,9 @@ async function yt2import() {
                 break;
             }
 
-            if ( data[accadd] )
-              addAcc += 1;
-            
+            if (data[accadd]) addAcc += 1;
+
             if (data[accname]) {
-            
               let dedicated = true;
               if (!data[accown]) dedicated = false;
               let matchItem = game.items.find(
@@ -819,39 +821,39 @@ async function yt2import() {
                 };
               }
               if (data[accown] == "HP") {
-                setData.effects =  [
-                 {
-                   name: "専用装飾品：最大HP増加",
-                   icon: "icons/svg/regen.svg",
-                   disabled: false,
-                   changes: [
-                     {
-                       mode: 2,
-                       value: "2",
-                       key: "system.hp.efhpmod"
-                     }
-                   ],
-                   transfer: true,
-                 }
-               ];
-             } else if (data[accown] == "MP") {
-                setData.effects =  [
-                 {
-                   name: "専用装飾品：最大MP増加",
-                   icon: "icons/svg/regen.svg",
-                   disabled: false,
-                   changes: [
-                     {
-                       mode: 2,
-                       value: "2",
-                       key: "system.mp.efmpmod"
-                     }
-                   ],
-                   transfer: true,
-                 }
-               ];
-             }
-             itemData.push(setData);
+                setData.effects = [
+                  {
+                    name: "専用装飾品：最大HP+2",
+                    icon: "icons/svg/regen.svg",
+                    disabled: false,
+                    changes: [
+                      {
+                        mode: 2,
+                        value: "2",
+                        key: "system.hp.efhpmod",
+                      },
+                    ],
+                    transfer: true,
+                  },
+                ];
+              } else if (data[accown] == "MP") {
+                setData.effects = [
+                  {
+                    name: "専用装飾品：最大MP+2",
+                    icon: "icons/svg/regen.svg",
+                    disabled: false,
+                    changes: [
+                      {
+                        mode: 2,
+                        value: "2",
+                        key: "system.mp.efmpmod",
+                      },
+                    ],
+                    transfer: true,
+                  },
+                ];
+              }
+              itemData.push(setData);
             }
           }
         }
@@ -1102,47 +1104,39 @@ async function yt2import() {
             });
           }
         }
-        
+
         // マテリアルカード追加
-        let materialE = ["Red","Gre","Bla","Whi","Gol"];
-        let materialJ = ["赤","緑","黒","白","金"];
-        let materialR = ["B","A","S","SS"];
+        let materialE = ["Red", "Gre", "Bla", "Whi", "Gol"];
+        let materialJ = ["赤", "緑", "黒", "白", "金"];
+        let materialR = ["B", "A", "S", "SS"];
         for (let i = 0; i < materialE.length; i++) {
           for (const crank of materialR) {
-            if(data["card" + materialE[i] + crank]){
-               let cardName = "マテリアルカード（"
-                 + materialJ[i]
-                 + crank
-                 + "）";
-               let quantity = parseInt(data["card" + materialE[i] + crank]);
+            if (data["card" + materialE[i] + crank]) {
+              let cardName = "マテリアルカード（" + materialJ[i] + crank + "）";
+              let quantity = parseInt(data["card" + materialE[i] + crank]);
 
-               let matchItem = game.items.find(
-                 (item) => item.name === cardName
-               );
-               if (!matchItem) {
-                 matchItem = await findEntryInCompendium(
-                   "Item",
-                   cardName
-                 );
-               }
-               if (matchItem) {
-                 let setData = duplicate(matchItem);
-                 setData.system.quantity = quantity;
-                 itemData.push(setData);
-               } else {
-                 itemData.push({
-                   name: data[`craftEnhance${i}`],
-                   type: "item",
-                   system: {
-                     quantity: quantity,
-                     description: "",
-                   },
-                 });
-               }
+              let matchItem = game.items.find((item) => item.name === cardName);
+              if (!matchItem) {
+                matchItem = await findEntryInCompendium("Item", cardName);
+              }
+              if (matchItem) {
+                let setData = duplicate(matchItem);
+                setData.system.quantity = quantity;
+                itemData.push(setData);
+              } else {
+                itemData.push({
+                  name: data[`craftEnhance${i}`],
+                  type: "item",
+                  system: {
+                    quantity: quantity,
+                    description: "",
+                  },
+                });
+              }
             }
           }
         }
-        
+
         // リソース追加
         for (const resource of resourceList) {
           let matchItem = game.items.find((item) => item.name === resource);
@@ -1219,7 +1213,7 @@ async function yt2import() {
               totalexp: data.expTotal,
             },
             hitweapon: hitweapon,
-            attackskill : data.weapon1Class,
+            attackskill: data.weapon1Class,
             dodgeskill: dodgeskill[1],
             herbskill: "レンジャー",
             potionskill: "レンジャー",
@@ -1294,7 +1288,6 @@ async function yt2import() {
           },
         ];
 
-
         let partsList = [];
         for (var i = 1; i <= actorNum; i++) {
           let mountLv = parseInt(data.lvMin)
@@ -1320,7 +1313,7 @@ async function yt2import() {
                 usedice2: true,
                 label2: "打撃",
                 checkbasemod2: itemDamage,
-                usefix2: usefix,
+                usefix2: false,
                 applycheck2: true,
                 usedice3: true,
                 label3: "回避",
@@ -1332,20 +1325,19 @@ async function yt2import() {
           }
           if (abidesc)
             partsList.push([
-             data["status" + i + "Style"],
-             eval(data["status" + access + "Accuracy"]),
-             data["status" + access + "Damage"],
-             eval(data["status" + access + "Evasion"]),
-             eval(data["status" + access + "Defense"]),
-             eval(data["status" + access + "Hp"]),
-             eval(data["status" + access + "Mp"]),
+              data["status" + i + "Style"],
+              eval(data["status" + access + "Accuracy"]),
+              data["status" + access + "Damage"],
+              eval(data["status" + access + "Evasion"]),
+              eval(data["status" + access + "Defense"]),
+              eval(data["status" + access + "Hp"]),
+              eval(data["status" + access + "Mp"]),
             ]);
         }
 
         if (abidesc)
           biography = getBiography(feature, data.description, partsList);
         else biography = "<h3><b>解説</b></h3>" + decodeHTML(data.description);
-
 
         if (monabi) {
           abilityList = analysisFeature(feature, usefix);
@@ -1372,7 +1364,7 @@ async function yt2import() {
             ? parseInt(data.lv) - parseInt(data.lvMin)
             : 0;
           let access = mountLv == 0 ? i : i + "-" + (mountLv + 1);
-          
+
           actorData = {
             name: actName,
             type: "monster",
@@ -1708,8 +1700,8 @@ function convertHtmlFromFeature(feature) {
   return ret;
 }
 
-function getBiography(feature, description, partsList){
-   let biography = `
+function getBiography(feature, description, partsList) {
+  let biography = `
       <table class="status">
         <thead>
           <tr>
@@ -1723,10 +1715,10 @@ function getBiography(feature, description, partsList){
         </thead>
         <tbody>
    `;
-   for ( const parts of partsList){
-     acc = parts[1] + 7;
-     eva = parts[3] + 7;
-     biography += `
+  for (const parts of partsList) {
+    acc = parts[1] + 7;
+    eva = parts[3] + 7;
+    biography += `
             <tr>
               <td class="pt-item">${parts[0]}
               <td class="pt-item">${parts[1]} (${acc})
@@ -1736,17 +1728,17 @@ function getBiography(feature, description, partsList){
               <td class="pt-item">${parts[5]}
               <td class="pt-item">${parts[6]}
      `;
-   }
-   biography += `
+  }
+  biography += `
         </tbody>
       </table>
    `;
 
-   biography +=
-     convertHtmlFromFeature(feature) +
-     "<br><h3><b>解説</b></h3>" +
-     decodeHTML(description);
-   return biography;
+  biography +=
+    convertHtmlFromFeature(feature) +
+    "<br><h3><b>解説</b></h3>" +
+    decodeHTML(description);
+  return biography;
 }
 
 // 全角半角変換関数

--- a/macro/yt2import.js
+++ b/macro/yt2import.js
@@ -742,69 +742,116 @@ async function yt2import() {
           "Other",
         ];
         for (let i = 0; i < accessorypart.length; i++) {
-          let accname = "accessory" + accessorypart[i] + "Name";
-          let accown = "accessory" + accessorypart[i] + "Own";
-          let accnote = "accessory" + accessorypart[i] + "Note";
-          let accpart;
-          switch (accessorypart[i]) {
-            case "Head":
-              accpart = "head";
-              break;
-            case "Face":
-              accpart = "face";
-              break;
-            case "Ear":
-              accpart = "ear";
-              break;
-            case "Neck":
-              accpart = "neck";
-              break;
-            case "Back":
-              accpart = "back";
-              break;
-            case "HandR":
-              accpart = "rhand";
-              break;
-            case "HandL":
-              accpart = "lhand";
-              break;
-            case "Waist":
-              accpart = "waist";
-              break;
-            case "Leg":
-              accpart = "leg";
-              break;
-            case "Other":
-              accpart = "other";
-              break;
-            default:
-              break;
-          }
-          if (data[accname]) {
-            let dedicated = true;
-            if (!data[accown]) dedicated = false;
-            let matchItem = game.items.find(
-              (item) => item.name === data[accname]
-            );
-            if (!matchItem) {
-              matchItem = await findEntryInCompendium("Item", data[accname]);
+          let addAcc = 0;
+          for (let j = 0; j <= addAcc ; j++) {
+            let underbar = "";
+            for (let k = 0; k < j; k++) {
+              underbar += "_";
             }
-            if (matchItem) {
-              let setData = duplicate(matchItem);
-              setData.system.equip = true;
-              setData.system.dedicated = dedicated;
-              itemData.push(setData);
-            } else {
-              itemData.push({
-                name: data[accname],
-                type: "accessory",
-                system: {
-                  description: data[accnote],
-                  equip: true,
-                  dedicated: dedicated,
-                  accpart: accpart,
-                },
-              });
+            let accname = "accessory" + accessorypart[i] + underbar + "Name";
+            let accown = "accessory" + accessorypart[i] + underbar + "Own";
+            let accnote = "accessory" + accessorypart[i] + underbar + "Note";
+            let accadd = "accessory" + accessorypart[i] + underbar + "Add";
+            
+            let accpart;
+            switch (accessorypart[i]) {
+              case "Head":
+                accpart = "head";
+                break;
+              case "Face":
+                accpart = "face";
+                break;
+              case "Ear":
+                accpart = "ear";
+                break;
+              case "Neck":
+                accpart = "neck";
+                break;
+              case "Back":
+                accpart = "back";
+                break;
+              case "HandR":
+                accpart = "rhand";
+                break;
+              case "HandL":
+                accpart = "lhand";
+                break;
+              case "Waist":
+                accpart = "waist";
+                break;
+              case "Leg":
+                accpart = "leg";
+                break;
+              case "Other":
+                accpart = "other";
+                break;
+              default:
+                break;
+            }
+
+            if ( data[accadd] )
+              addAcc += 1;
+            
+            if (data[accname]) {
+            
+              let dedicated = true;
+              if (!data[accown]) dedicated = false;
+              let matchItem = game.items.find(
+                (item) => item.name === data[accname]
+              );
+              if (!matchItem) {
+                matchItem = await findEntryInCompendium("Item", data[accname]);
+              }
+              if (matchItem) {
+                let setData = duplicate(matchItem);
+                setData.system.equip = true;
+                setData.system.dedicated = dedicated;
+              } else {
+                setData = {
+                  name: data[accname],
+                  type: "accessory",
+                  system: {
+                    description: data[accnote],
+                    equip: true,
+                    dedicated: dedicated,
+                    accpart: accpart,
+                  },
+                };
+              }
+              if (data[accown] == "HP") {
+                setData.effects =  [
+                 {
+                   name: "専用装飾品：最大HP増加",
+                   icon: "icons/svg/regen.svg",
+                   disabled: false,
+                   changes: [
+                     {
+                       mode: 2,
+                       value: "2",
+                       key: "system.hp.efhpmod"
+                     }
+                   ],
+                   transfer: true,
+                 }
+               ];
+             } else if (data[accown] == "MP") {
+                setData.effects =  [
+                 {
+                   name: "専用装飾品：最大MP増加",
+                   icon: "icons/svg/regen.svg",
+                   disabled: false,
+                   changes: [
+                     {
+                       mode: 2,
+                       value: "2",
+                       key: "system.mp.efmpmod"
+                     }
+                   ],
+                   transfer: true,
+                 }
+               ];
+             }
+             itemData.push(setData);
             }
           }
         }

--- a/macro/yt2import.js
+++ b/macro/yt2import.js
@@ -12,10 +12,10 @@ async function yt2import() {
       <p><input type="file" id="json-file-input" accept=".json" style="width: 100%;" /></p>
       <p></p>
       <p><b>魔物インポートオプション</b></p>
-      <p><input id="abilist" type="checkbox" data-dtype="Boolean"/><label for="abilist">魔物能力一覧アイテムを作成</label></p>
-      <p><input id="abidesc" type="checkbox" data-dtype="Boolean" checked/><label for="abilist">魔物能力一覧を説明タブに展開</label></p>
-      <p><input id="monabi" type="checkbox" data-dtype="Boolean" checked/><label for="monabi">魔物能力の個別アイテムを作成</label></p>
-      <p><input id="allattack" type="checkbox" data-dtype="Boolean" checked/><label for="allattack">多部位魔物：全部位分の攻撃を作成</label></p>
+      <p><input id="abilist" type="checkbox" data-dtype="Boolean" checked/><label for="abilist">魔物能力一覧アイテムを作成</label></p>
+      <p><input id="abidesc" type="checkbox" data-dtype="Boolean"/><label for="abilist">魔物能力一覧を説明タブに展開</label></p>
+      <p><input id="monabi" type="checkbox" data-dtype="Boolean"/><label for="monabi">魔物能力の個別アイテムを作成</label></p>
+      <p><input id="allattack" type="checkbox" data-dtype="Boolean"/><label for="allattack">多部位魔物：全部位分の攻撃を作成</label></p>
       <p><input id="usefix" type="checkbox" data-dtype="Boolean" checked/><label for="usefix">魔物能力で固定値を使用</label></p>
     `;
 

--- a/module/sw25.mjs
+++ b/module/sw25.mjs
@@ -133,6 +133,96 @@ Handlebars.registerHelper("localizeAbility", function (ability) {
   }
 });
 
+Handlebars.registerHelper("localizeResist", function (resist) {
+  switch (resist) {
+    case "decide":
+      return game.i18n.localize("SW25.Item.Decide");
+    case "any":
+      return game.i18n.localize("SW25.Item.Any");
+    case "none":
+      return game.i18n.localize("SW25.Item.None");
+    case "disappear":
+      return game.i18n.localize("SW25.Item.Disappear");
+    case "halving":
+      return game.i18n.localize("SW25.Item.Halving");
+    case "shortening":
+      return game.i18n.localize("SW25.Item.Shortening");
+  }
+  return "-";
+});
+
+Handlebars.registerHelper("localizeProp", function (prop) {
+  switch (prop) {
+    case "earth":
+      return game.i18n.localize("SW25.Item.Earth");
+    case "ice":
+      return game.i18n.localize("SW25.Item.Ice");
+    case "fire":
+      return game.i18n.localize("SW25.Item.Fire");
+    case "wind":
+      return game.i18n.localize("SW25.Item.Wind");
+    case "thunder":
+      return game.i18n.localize("SW25.Item.Thunder");
+    case "energy":
+      return game.i18n.localize("SW25.Item.Energy");
+    case "cut":
+      return game.i18n.localize("SW25.Item.Cut");
+    case "impact":
+      return game.i18n.localize("SW25.Item.Impact");
+    case "poison":
+      return game.i18n.localize("SW25.Item.Poison");
+    case "disease":
+      return game.i18n.localize("SW25.Item.Disease");
+    case "mental":
+      return game.i18n.localize("SW25.Item.Mental");
+    case "mentalw":
+      return game.i18n.localize("SW25.Item.Mentalw");
+    case "curse":
+      return game.i18n.localize("SW25.Item.Curse");
+    case "curseMental":
+      return game.i18n.localize("SW25.Item.CurseMental");
+    case "mentalPoison":
+      return game.i18n.localize("SW25.Item.MentalPoison");
+    case "other":
+      return game.i18n.localize("SW25.Item.Other");
+    case "fandw":
+      return game.i18n.localize("SW25.Item.Fandw");
+    case "iandt":
+      return game.i18n.localize("SW25.Item.Iandt");
+  }
+  return "-";
+});
+
+
+Handlebars.registerHelper("localizeFairyProp", function (fairyprop) {
+  switch (fairyprop) {
+    case "fairyearth":
+      return game.i18n.localize("SW25.Item.Spell.Fairyearth");
+    case "fairyice":
+      return game.i18n.localize("SW25.Item.Spell.Fairyice");
+    case "fairyfire":
+      return game.i18n.localize("SW25.Item.Spell.Fairyfire");
+    case "fairywind":
+      return game.i18n.localize("SW25.Item.Spell.Fairywind");
+    case "fairylight":
+      return game.i18n.localize("SW25.Item.Spell.Fairylight");
+    case "fairydark":
+      return game.i18n.localize("SW25.Item.Spell.Fairydark");
+  }
+  return "-";
+});
+
+Handlebars.registerHelper("localizePhasetype", function (phasetype) {
+  switch (phasetype) {
+    case "ten":
+      return game.i18n.localize("SW25.Item.Phasearea.Ten");
+    case "chi":
+      return game.i18n.localize("SW25.Item.Phasearea.Chi");
+    case "jin":
+      return game.i18n.localize("SW25.Item.Phasearea.Jin");
+  }
+  return "-";
+});
 /* -------------------------------------------- */
 /*  Ready Hook                                  */
 /* -------------------------------------------- */

--- a/templates/item/item-alchemytech-sheet.hbs
+++ b/templates/item/item-alchemytech-sheet.hbs
@@ -21,7 +21,7 @@
           <b>{{localize "SW25.Time"}} : </b>{{system.time}} 
         </div>
         <div class="grid-span-2">
-           <b>{{localize "SW25.Item.Resist"}} : </b>{{system.resistname}}
+           <b>{{localize "SW25.Item.Resist"}} : </b>{{localizeResist system.resist}}
         </div>
         <div class="grid-span-2">
            <b>{{localize "SW25.Cost"}} : </b>

--- a/templates/item/item-enhancearts-sheet.hbs
+++ b/templates/item/item-enhancearts-sheet.hbs
@@ -12,7 +12,7 @@
         </div>
         <div class="grid-span-2"></div>
         <div class="grid-span-2">
-          <b>MP{{localize "SW25.Cost"}} : </b>{{system.mpcost}}
+          <b>MP{{localize "SW25.Cost"}} : </b>{{system.basempcost}}
         </div>
         <div class="grid-span-2">
           <b>{{localize "SW25.Time"}} : </b>{{system.time}} 

--- a/templates/item/item-magicalsong-sheet.hbs
+++ b/templates/item/item-magicalsong-sheet.hbs
@@ -8,10 +8,10 @@
           <b>{{system.level}}{{localize "SW25.Level"}}{{system.typename}}</b>
         </div>
         <div class="grid-span-2">
-           <b>{{localize "SW25.Item.Resist"}} : </b>{{system.resistname}}
+           <b>{{localize "SW25.Item.Resist"}} : </b>{{localizeResist system.resist}}
         </div>
         <div class="grid-span-2">
-           <b>{{localize "SW25.Item.Prop"}} : </b>{{system.propname}}
+           <b>{{localize "SW25.Item.Prop"}} : </b>{{localizeProp system.prop}}
         </div>
         {{#if (eq system.type "song")}}
         <div class="grid-span-2">

--- a/templates/item/item-phasearea-sheet.hbs
+++ b/templates/item/item-phasearea-sheet.hbs
@@ -5,7 +5,7 @@
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
       <div class="grid grid-6col flex-group-left nogapmargin">
         <div class="grid-span-2">
-          <b>{{system.typename}}{{localize "SW25.Item.Phasearea.Phase"}}</b>
+          <b>{{localizePhasetype system.type}}{{localize "SW25.Item.Phasearea.Phase"}}</b>
         </div>
         <div class="grid-span-2">
           <b>{{system.level}}{{localize "SW25.Level"}}{{localize "TYPES.Item.phasearea"}}</b>
@@ -18,7 +18,7 @@
            <b>{{localize "SW25.Time"}} : </b>{{system.time}} 
         </div>
         <div class="grid-span-2">
-           <b>{{localize "SW25.Item.Prop"}} : </b>{{system.propname}}
+           <b>{{localize "SW25.Item.Prop"}} : </b>{{localizeProp system.prop}}
         </div>
         <div class="grid-span-6">
           <b>{{localize "SW25.Item.Overview"}} : </b>{{system.overview}}

--- a/templates/item/item-spell-sheet.hbs
+++ b/templates/item/item-spell-sheet.hbs
@@ -23,10 +23,10 @@
           <b>{{localize "SW25.Time"}} : </b>{{system.time}} 
         </div>
         <div class="grid-span-2">
-           <b>{{localize "SW25.Item.Resist"}} : </b>{{#if system.hpresist}}{{localize "SW25.Item.Spell.Hpresist"}}/{{/if}}{{system.resistname}}
+           <b>{{localize "SW25.Item.Resist"}} : </b>{{#if system.hpresist}}{{localize "SW25.Item.Spell.Hpresist"}}/{{/if}}{{localizeResist system.resist}}
         </div>
         <div class="grid-span-2">
-           <b>{{localize "SW25.Item.Prop"}} : </b>{{system.propname}}
+           <b>{{localize "SW25.Item.Prop"}} : </b>{{localizeProp system.prop}}
         </div>
         {{#if (eq system.type "priest")}}
           {{#if system.sect}}
@@ -42,7 +42,7 @@
         {{/if}}
         {{#if (eq system.type "fairy")}}
         <div class="grid-span-6">
-          <b>{{system.fairytypename}}{{localize "SW25.Item.Spell.Fairy"}}{{#if (eq system.fairytype "propfairy")}} ({{system.fairypropname}}){{/if}}</b>
+          <b>{{system.fairytypename}}{{localize "SW25.Item.Spell.Fairy"}}{{#if (eq system.fairytype "propfairy")}} ({{localizeFairyProp system.fairyprop}}){{/if}}</b>
         </div>
         {{/if}}
         <div class="grid-span-6">


### PR DESCRIPTION
以下の内容が取り込まれています。

【問題の修正】
・多部位魔物：全部位攻撃作成について、ラベルをクリックしてもチェックボックスが変化しない問題の修正
・魔物データの表記について、演算子がついているケースを対応
　→例として、HP欄に「50+10」のような記載をしている場合、「60」として登録するように修正。
・魔物データの攻撃等データについて、部位数ではなくステータス数を参照するように修正
　→ヒドラ、コープスコープスのように、同一データを複数持つような場合は部位数とステータス数が異なるため。

【キャラクターインポート機能】
・武器選択の自動化
　→武器欄の一番上にあるものを自動的に選択します。
・回避技能の自動化
　→戦士系技能、および、射手の体術取得時のシューターの中から最高レベルのものを自動的に選択します。
・各種技能の標準値設定の自動化
　→各魔法、薬草、修理具について、適切な技能を自動的に選択します。
　　（各魔法は未習得で設定しても、自動的に削除されるようなので固定値で設定し、
　　　深智魔法のみソーサラー、コンジャラーのうち高レベルのものを選択する）
・所持マテリアルカードの自動追加
　→マテリアルカード欄に入力している個数分、所持アイテムとして自動的に追加します。
・アクセサリ専用化（HP増強、MP増強）の追加
　→HP専用化、MP専用化しているアクセサリを含む場合、自動的に常時バフとして取り込みます。
　　HP専用化アクセサリを複数装着している場合、本来効果がありませんが、その分だけ増加します。
・アクセサリ複数の取り込み機能追加
　→野伏の＊＊マント、レプラカーンの種族特徴等により、複数のアクセサリを装着している場合、すべて取り込みます。

【魔物インポート機能】
・魔物能力で固定値を使用するかどうかの選択を追加（デフォルト：固定値を使用）
　→チェックを外してインポートした場合、魔物能力の各能力値が2d6+修正値になります。
・魔物データの攻撃等データについて、説明欄に展開するように追加
　→「魔物能力一覧を説明タブに展開」向けの機能追加

【ゆとシート以外】
・魔法などにおいて、「属性」「抵抗」「妖精属性」などが表示されない問題の修正