### PR TITLE
Add Loot button to get the loot

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -72,6 +72,7 @@
     "Notargetwarn": "No targets selected.",
     "Multitargetwarn": "Multi targets selected.",
     "Noselectwarn": "No Token selected.",
+    "Characterselectwarn": "The target is not a character.",
     "Multiselectwarn": "Multi Tokens selected.",
     "InputPlaceHolder": "Input here.",
 
@@ -143,6 +144,7 @@
       "Corepart": "Core Part",
       "Ability": "Ability",
       "Loot": "Loot",
+      "AddLoot": "Add Loot",
       "Usespell": "Use Spells",
       "Unidentifiedmon": "Unidentified Monster"
     },

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -72,6 +72,7 @@
     "Notargetwarn": "ターゲットが指定されていません",
     "Multitargetwarn": "ターゲットが複数指定されています",
     "Noselectwarn": "トークンが選択されていません",
+    "Characterselectwarn": "キャラクターシートが選択されていません",
     "Multiselectwarn": "トークンが複数選択されています",
     "InputPlaceHolder": "ここに入力",
 
@@ -143,6 +144,7 @@
       "Corepart": "コア部位",
       "Ability": "魔物能力",
       "Loot": "戦利品",
+      "AddLoot": "追加戦利品",
       "Usespell": "魔法使用",
       "Unidentifiedmon": "不明の魔物"
     },

--- a/templates/roll/roll-check.hbs
+++ b/templates/roll/roll-check.hbs
@@ -12,10 +12,14 @@
             <span class="diceresult-total">
                 {{#if critical}} <span class="success">{{localize "SW25.Critical"}} ▶ </span>{{/if}}
                 {{#if fumble}} <span class="failed">{{localize "SW25.Fumble"}} ▶ </span>{{/if}}
-                {{#if chatLootItem}}<span style="font-size:0.7em;">{{/if}}
+                {{#if chatLootItems.length}}<span style="font-size:0.7em;">{{/if}}
                 {{{resultText}}}
                 {{{total}}}
-                {{#if chatLootItem}}: </span><span class="success">{{chatLootItem}}</span>{{/if}}
+                {{#if chatLootItems.length}}: </span>
+                    {{#each chatLootItems}}
+                        <span class="success">{{this}}</span>{{#unless @last}}, {{/unless}}
+                    {{/each}}
+                {{/if}}
             </span>
             <span class="buttonclick quantitychange" data-buttontype="checkincrease">&nbsp;+&nbsp;</span>
         </h4>
@@ -28,6 +32,11 @@
         {{/if}}
     </div>
 </div>
+{{#if chatLootItems.length}}
+  <button class="buttonclick" data-buttontype="buttonaddloot" data-loot="{{chatLootString}}">
+    {{localize "SW25.Monster.AddLoot"}}
+  </button>
+{{/if}}
 <div class="dice-flavor">{{{resusetext}}}</div>
 {{#if (eq apply "custom")}}
 <div>

--- a/templates/roll/roll-loot.hbs
+++ b/templates/roll/roll-loot.hbs
@@ -1,0 +1,11 @@
+{{#if flavor}}<span class="flavor-text">{{flavor}}</span>{{/if}}
+
+{{#each actorLoot}}
+  <div style="text-align: center; font-size: 1em;">
+    <strong>{{loot}}:</strong> {{oldQuantity}} >>> {{newQuantity}}
+  </div>
+{{/each}}
+
+<div style="text-align: center;">
+  <div style="text-align: right; font-size: 0.7em;"> >>><span style="font-size:1.2em;"> {{target}}</span></div>
+</div>


### PR DESCRIPTION
Hello, hello again!

Today I worked in a feature you may like, it's for the loot and be able to automatically add it to the inventory without having to manually write it.

First I thought I would atomatically add the loot to the player that made the roll, but for more personalization I just added a button to add it to the selected actor (only for characters).

![image](https://github.com/user-attachments/assets/ee99a7e2-3fb7-454b-8b18-b4b45d632b6b)

And after clicking it the item will be automatically added in the actor.

![image](https://github.com/user-attachments/assets/95a921c5-feb8-4c37-9099-0857cd7e5089)

If the same item exists (checks the name only) then adds it to the quantity.

![image](https://github.com/user-attachments/assets/a3fba75c-16b1-4290-a03f-c219541ed4ed)

Here's now an example of the second loot available.

![image](https://github.com/user-attachments/assets/e7fcee00-c371-47e4-b153-149bc985087c)

Now here's a new part, I tweak the logic a bit to be able to put those loots that are "always", now it's an array of items instead of only one, and you can see each one adds.

![image](https://github.com/user-attachments/assets/5e13f0da-9ab0-4926-9ce0-05a550d3aa2e)

And another example of it!

![image](https://github.com/user-attachments/assets/0516f51d-97a2-4e87-8e35-4f05b786383a)

Hope you like, maybe the tweak can change the loot a bit, a known issue for this is for example in the next capture the loot could be trigger multiple times depending on the structure, but actually it could give more personalization, some players may want multiple "always" loot depending on the result... but again I don't want to change the system a lot.

![image](https://github.com/user-attachments/assets/e81fbf83-b6b3-4b39-913a-5df051ebf5c4)

Finally, another issue could be duplicated loot, since it checks the name only.