### PR TITLE
Bug Fix

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1564,8 +1564,6 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1573,35 +1571,40 @@ export class SW25Item extends Item {
       systemData.typename = game.i18n.localize(`SW25.Item.Item.${i18ntype}`);
     } else systemData.typename = game.i18n.localize(`SW25.Item.Item.General`);
 
-    // Set default skill and ability
-    if (systemData.type == "herb") {
-      if (actorData.herbskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.herbskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "dex";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.herbskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "dex";
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+
+      // Set default skill and ability
+      if (systemData.type == "herb") {
+        if (actorData.herbskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.herbskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "dex";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.herbskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "dex";
+        }
       }
-    }
-    if (systemData.type == "potion") {
-      if (actorData.potionskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.potionskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.potionskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "potion") {
+        if (actorData.potionskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.potionskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.potionskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "repair") {
-      if (actorData.repairskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.repairskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "dex";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.repairskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "dex";
+      if (systemData.type == "repair") {
+        if (actorData.repairskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.repairskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "dex";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.repairskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "dex";
+        }
       }
     }
   }
@@ -1688,8 +1691,6 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
 
     if (systemData.category != "-") {
       const i18ncat =
@@ -1729,14 +1730,19 @@ export class SW25Item extends Item {
       else systemData.showskill = systemData.checkskill;
     }
 
-    // Set default skill and ability
-    if (actorData.attackskill != "-") {
-      if (systemData.checkskill == "-")
-        systemData.checkskill = actorData.attackskill;
-      if (systemData.checkabi == "-") systemData.checkabi = "dex";
-      if (systemData.powerskill == "-")
-        systemData.powerskill = actorData.attackskill;
-      if (systemData.powerabi == "-") systemData.powerabi = "str";
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+
+      // Set default skill and ability
+      if (actorData.attackskill != "-") {
+        if (systemData.checkskill == "-")
+          systemData.checkskill = actorData.attackskill;
+        if (systemData.checkabi == "-") systemData.checkabi = "dex";
+        if (systemData.powerskill == "-")
+          systemData.powerskill = actorData.attackskill;
+        if (systemData.powerabi == "-") systemData.powerabi = "str";
+      }
     }
   }
 
@@ -1745,8 +1751,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.accpart != "-") {
       const i18npart =
@@ -1767,8 +1776,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.category != "-") {
       const i18ncat =
@@ -1785,8 +1797,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1813,8 +1828,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1857,8 +1875,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.resist != "-") {
       const i18nresist =
@@ -1878,8 +1899,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1904,8 +1928,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1927,8 +1954,11 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
+
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+    }
 
     if (systemData.resist != "-") {
       const i18nresist =
@@ -1947,8 +1977,6 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
-    const actorData = itemData.actor.system;
-    const actoritemData = itemData.actor.items;
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1986,95 +2014,100 @@ export class SW25Item extends Item {
       );
     } else systemData.fairypropname = "-";
 
-    // Set default skill and ability
-    if (systemData.type == "sorcerer") {
-      if (actorData.scskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.scskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.scskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+    if (itemData.actor !== null) {
+      const actorData = itemData.actor.system;
+      const actoritemData = itemData.actor.items;
+
+      // Set default skill and ability
+      if (systemData.type == "sorcerer") {
+        if (actorData.scskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.scskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.scskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "conjurer") {
-      if (actorData.cnskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.cnskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.cnskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "conjurer") {
+        if (actorData.cnskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.cnskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.cnskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "wizard") {
-      if (actorData.wzskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.wzskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.wzskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "wizard") {
+        if (actorData.wzskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.wzskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.wzskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "priest") {
-      if (actorData.prskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.prskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.prskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "priest") {
+        if (actorData.prskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.prskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.prskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "magitech") {
-      if (actorData.mtskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.mtskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.mtskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "magitech") {
+        if (actorData.mtskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.mtskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.mtskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "fairy") {
-      if (actorData.frskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.frskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.frskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "fairy") {
+        if (actorData.frskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.frskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.frskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "druid") {
-      if (actorData.drskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.drskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.drskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "druid") {
+        if (actorData.drskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.drskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.drskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "daemon") {
-      if (actorData.dmskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.dmskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.dmskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "daemon") {
+        if (actorData.dmskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.dmskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.dmskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
-    }
-    if (systemData.type == "abyssal") {
-      if (actorData.abskill != "-") {
-        if (systemData.checkskill == "-")
-          systemData.checkskill = actorData.abskill;
-        if (systemData.checkabi == "-") systemData.checkabi = "int";
-        if (systemData.powerskill == "-")
-          systemData.powerskill = actorData.abskill;
-        if (systemData.powerabi == "-") systemData.powerabi = "int";
+      if (systemData.type == "abyssal") {
+        if (actorData.abskill != "-") {
+          if (systemData.checkskill == "-")
+            systemData.checkskill = actorData.abskill;
+          if (systemData.checkabi == "-") systemData.checkabi = "int";
+          if (systemData.powerskill == "-")
+            systemData.powerskill = actorData.abskill;
+          if (systemData.powerabi == "-") systemData.powerabi = "int";
+        }
       }
     }
   }

--- a/template.json
+++ b/template.json
@@ -471,7 +471,7 @@
       "battle": {
         "equip": true,
         "dedicated": false,
-        "category": "",
+        "category": "-",
         "rank": "",
         "reqstr": ""
       },
@@ -585,9 +585,9 @@
     },
     "tactics": {
       "templates": ["base", "roll", "ability"],
-      "type": "",
+      "type": "-",
       "cost": "",
-      "line": "",
+      "line": "-",
       "rank": "",
       "get": "",
       "premise": "",


### PR DESCRIPTION
ItemのActorが存在しないときに発生するエラーを抑制しました
これによりActorが存在しないときのアイテム概要が（例えば武器種別や戦闘特技の条件など），正常に表示されるようになります

itemDataとactorを引数に取る_prepare.+?Data()については未着手，今後対応します

## before
![Screen Shot 2024-12-26 at 2 58 59](https://github.com/user-attachments/assets/ea13fb9a-707d-4357-825d-e035b52f84c0)

## after
![Screen Shot 2024-12-26 at 3 00 00](https://github.com/user-attachments/assets/7ca4c5ee-d19b-4d2d-9a73-b36f0a3f6e44)
