### PR TITLE
数点の機能追加／

### DIFF
--- a/css/sw25.css
+++ b/css/sw25.css
@@ -59,6 +59,18 @@
   cursor: pointer;
 }
 
+.popularityrollable:hover, .popularityrollable:focus {
+  color: #000;
+  text-shadow: 0 0 10px red;
+  cursor: pointer;
+}
+
+.preemptiverollable:hover, .preemptiverollable:focus {
+  color: #000;
+  text-shadow: 0 0 10px red;
+  cursor: pointer;
+}
+
 .quantitychange:hover, .quantitychange:focus {
   color: #000;
   text-shadow: 0 0 10px red;

--- a/css/sw25.css
+++ b/css/sw25.css
@@ -594,6 +594,9 @@ progress.mp-bar::-moz-progress-bar {
   flex: 0 auto;
   overflow: hidden;
   height: auto;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }
 .sw25 .sheet-header h1.charname {
   height: 50px;
@@ -608,6 +611,11 @@ progress.mp-bar::-moz-progress-bar {
 }
 .sw25 .sheet-tabs {
   flex: 0;
+  position: sticky;
+  top: 0px;
+  z-index: 1002;
+  background-color: var(--background-color, #dad8cc);
+  border-bottom: 1px solid #444;
 }
 .sw25 .sheet-tabs.tabs {
   border: 0;
@@ -642,7 +650,14 @@ progress.mp-bar::-moz-progress-bar {
 }
 
 .sw25 .sheet-body {
+  position: sticky;
   padding: 5px;
+  flex: 1;
+  overflow-y: auto;
+  margin-top: auto;
+  z-index: 1001;
+  background-color: var(--background-color, #dad8cc);
+  border-bottom: 1px solid #444;
 }
 
 .sw25 .sheet-body input:hover,

--- a/css/sw25.css
+++ b/css/sw25.css
@@ -71,6 +71,12 @@
   cursor: pointer;
 }
 
+.usephasearea:hover, .usephasearea:focus {
+  color: #000;
+  text-shadow: 0 0 10px red;
+  cursor: pointer;
+}
+
 .quantitychange:hover, .quantitychange:focus {
   color: #000;
   text-shadow: 0 0 10px red;
@@ -1338,4 +1344,112 @@ input.weakapply[type="checkbox"] {
 
 .target-select .selectable:hover{
   text-shadow: 0 0 10px red;
+}
+
+.materialcard{
+  font-size: 0.8em;
+}
+
+.materialcard .green{
+  background-color: #abf3c8;
+}
+
+.materialcard .red{
+  background-color:#f3aba0
+}
+
+.materialcard .gold{
+  background-color:#ffff88;
+}
+
+.materialcard .black{
+  background-color:#999999;
+}
+
+.materialcard .white{
+  background-color:#eeeeee;
+}
+
+.materialcard .quantity{
+  text-align:center;
+  flex: 0 0 90px;
+}
+
+.sw25 .ability-resource {
+  font-size: 0.8em;
+  margin: 2px 0;
+  padding: 0;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.05);
+  border: 2px groove #eeede0;
+  font-weight: bold;
+  font-size: 14px;
+  text-align: center;
+}
+
+.sw25 .ability-resource .abirity-label{
+  font-weight: bold;
+  text-align: center;
+  min-width: 3em;
+}
+
+.materialcardcost{
+  font-weight: bold;
+  text-align: center;
+  margin: 2px;
+}
+
+.materialcardcost:hover, .usephasearea:focus {
+  color: #000;
+  text-shadow: 0 0 10px red;
+  cursor: pointer;
+}
+
+.fairy-checkbox {
+  display: grid;
+  grid-column: span 6/span 6;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: var(--spacing-sm);
+  margin: 0px 0;
+  padding: 0;
+  place-items: center;
+}
+
+.fairy-contract {
+  width: 20px;
+  border: 1px solid #000;
+  border-radius: 5px;
+  text-align: center;
+  cursor: pointer;
+  background-color: #dad8cc;
+  transition: background-color 0.3s ease;
+  font-size: 0.7em;
+}
+
+.fairy-contract.f-earth.checked {
+  background-color: #e9d1a0;
+}
+
+.fairy-contract.f-water.checked {
+  background-color: #9bbdec;
+}
+
+.fairy-contract.f-fire.checked {
+  background-color: #e8979f;
+}
+
+.fairy-contract.f-wind.checked {
+  background-color: #9be49f;
+}
+
+.fairy-contract.f-light.checked {
+  background-color: #e7e3ea;
+}
+
+.fairy-contract.f-dark.checked {
+  background-color: #9c979f;
+}
+
+.fairy-rank {
+  font-size: 0.7em;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -460,7 +460,7 @@
         },
         "Deamonblood": "Deamon Blood",
         "Deamoncrystal": "Deamon Crystal",
-        "DeamoncrystalLarge": "Deamon Large Crystal",
+        "DeamoncrystalLarge": "Arcdeamon Crystal",
         "Abyssshard": "Abyss Shard"
       },
       "Combatability": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -87,6 +87,9 @@
     "InputPlaceHolder": "Input here.",
     "NotTokenwarn": "No Token in canvas.",
 
+    "NotResource": "Resource is not found.",
+    "InputPhaseareaPoint": "Input use point.",
+
     "Disposition": {
       "Friendly": "Friendly",
       "Neutral": "Neutral",
@@ -171,6 +174,7 @@
       "ActiveEffect": "SW25 Effect Sheet"
     },
     "Item": {
+      "Name": "Name",
       "CheckB": "<CK>",
       "PowerB": "<PWR>",
       "EffectB": "<EFF>",
@@ -356,6 +360,15 @@
         "Fairywind": "Wind",
         "Fairylight": "Light",
         "Fairydark": "Dark",
+        "FairyContract":{
+          "Rank": "Rank",
+          "Earth": "Ea",
+          "Water": "Wa",
+          "Fire": "Fi",
+          "Wind": "Wi",
+          "Light": "Li",
+          "Dark": "Da"
+        },
         "Hpresist": "Fortitude",
         "Meta": "Meta",
         "Cancel": "Cancel",
@@ -382,14 +395,20 @@
         "Support": "Supported Mount"
       },
       "Alchemytech": {
+        "MaterialCard": "Material Card",
         "Red": "Red",
         "Green": "Green",
         "Black": "Black",
         "White": "White",
-        "Gold": "Gold"
+        "Gold": "Gold",
+        "B": "B",
+        "A": "A",
+        "S": "S",
+        "SS": "SS"
       },
       "Phasearea": {
         "Phase": "Aspect",
+        "Point": "Pt",
         "Lifeline": "Qi",
         "Ten": "Heaven",
         "Chi": "Earth",
@@ -422,6 +441,20 @@
         "Powerroll": "Power Roll"
       },
       "Resource": {
+        "Battle": "Not Battle",
+        "Type": "Resource Type",
+        "Types": {
+          "None": "None",
+          "Note": "Music",
+          "Material": "Material Card",
+          "Lifeline": "Qi",
+          "Tacspower": "Edge",
+          "AbyssEx": "Abyss Extend"
+        },
+        "Deamonblood": "Deamon Blood",
+        "Deamoncrystal": "Deamon Crystal",
+        "DeamoncrystalLarge": "Deamon Large Crystal",
+        "Abyssshard": "Abyss Shard"
       },
       "Combatability": {
         "Type": "Type",

--- a/lang/en.json
+++ b/lang/en.json
@@ -438,7 +438,14 @@
       "Check": {
         "Normalcheck": "Normal Check",
         "Customroll": "Custom Dice Check",
-        "Powerroll": "Power Roll"
+        "Powerroll": "Power Roll",
+        "Package": "Check Package",
+        "Packages": {
+          "Finesse": "Finesse",
+          "Movement": "Movement",
+          "Observation": "Observation",
+          "Knowledge": "Knowledge"
+        }
       },
       "Resource": {
         "Battle": "Not Battle",

--- a/lang/en.json
+++ b/lang/en.json
@@ -90,6 +90,8 @@
     "NotResource": "Resource is not found.",
     "InputPhaseareaPoint": "Input use point.",
 
+    "TurnendEffect": "Turn end effect",
+
     "Disposition": {
       "Friendly": "Friendly",
       "Neutral": "Neutral",
@@ -552,6 +554,8 @@
       "MppMod": "MDEF Mod",
       "Dreduce": "DMG Reduce",
       "MoveMod": "Move Mod",
+      "HpregenMod": "Hp regen Mod",
+      "MpregenMod": "Mp regen Mod",
       "HpMod": "Max HP Mod",
       "MpMod": "Max MP Mod",
       "DexValueModify": "Ability(Dex)",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -461,7 +461,7 @@
         },
         "Deamonblood": "悪魔の血",
         "Deamoncrystal": "悪魔の血晶",
-        "DeamoncrystalLarge": "悪魔の大血晶",
+        "DeamoncrystalLarge": "大悪魔の血晶",
         "Abyssshard": "アビスシャード"
       },
       "Combatability": {

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -439,7 +439,14 @@
       "Check": {
         "Normalcheck": "通常判定",
         "Customroll": "カスタムダイス",
-        "Powerroll": "威力ロール"
+        "Powerroll": "威力ロール",
+        "Package": "判定パッケージ",
+        "Packages": {
+          "Finesse": "技巧",
+          "Movement": "運動",
+          "Observation": "観察",
+          "Knowledge": "知識"
+        }
       },
       "Resource": {
         "Battle": "戦闘タブ非表示",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -91,6 +91,8 @@
     "NotResource": "該当リソースなし",
     "InputPhaseareaPoint": "使用命脈点を入力",
 
+    "TurnendEffect": "ターン終了時効果",
+
     "Disposition": {
       "Friendly": "友好",
       "Neutral": "中立",
@@ -552,6 +554,8 @@
       "MppMod": "魔法防御修正",
       "Dreduce": "ダメージ軽減",
       "MoveMod": "移動力修正",
+      "HpregenMod": "HP継続回復",
+      "MpregenMod": "MP継続回復",
       "HpMod": "最大HP修正",
       "MpMod": "最大MP修正",
       "DexValueModify": "器用度",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -88,6 +88,9 @@
     "InputPlaceHolder": "ここに入力",
     "NotTokenwarn": "トークンが存在しません。",
 
+    "NotResource": "該当リソースなし",
+    "InputPhaseareaPoint": "使用命脈点を入力",
+
     "Disposition": {
       "Friendly": "友好",
       "Neutral": "中立",
@@ -172,6 +175,7 @@
       "ActiveEffect": "SW25バフデバフシート"
     },
     "Item": {
+      "Name": "名称",
       "CheckB": "判定",
       "PowerB": "威力",
       "EffectB": "バフ",
@@ -357,6 +361,15 @@
         "Fairywind": "風",
         "Fairylight": "光",
         "Fairydark": "闇",
+        "FairyContract":{
+          "Rank": "ランク",
+          "Earth": "土",
+          "Water": "水",
+          "Fire": "炎",
+          "Wind": "風",
+          "Light": "光",
+          "Dark": "闇"
+        },
         "Hpresist": "生命",
         "Meta": "拡大",
         "Cancel": "取消",
@@ -383,14 +396,20 @@
         "Support": "対応"
       },
       "Alchemytech": {
+        "MaterialCard": "マテリアルカード",
         "Red": "赤",
         "Green": "緑",
         "Black": "黒",
         "White": "白",
-        "Gold": "金"
+        "Gold": "金",
+        "B": "B",
+        "A": "A",
+        "S": "S",
+        "SS": "SS"
       },
       "Phasearea": {
         "Phase": "相",
+        "Point": "命脈点",
         "Lifeline": "命脈",
         "Ten": "天",
         "Chi": "地",
@@ -423,6 +442,20 @@
         "Powerroll": "威力ロール"
       },
       "Resource": {
+        "Battle": "戦闘タブ非表示",
+        "Type": "リソース種別",
+        "Types": {
+          "None": "なし",
+          "Note": "楽素",
+          "Material": "マテリアルカード",
+          "Lifeline": "命脈点",
+          "Tacspower": "陣気",
+          "AbyssEx": "奈落魔法拡張素材"
+        },
+        "Deamonblood": "悪魔の血",
+        "Deamoncrystal": "悪魔の血晶",
+        "DeamoncrystalLarge": "悪魔の大血晶",
+        "Abyssshard": "アビスシャード"
       },
       "Combatability": {
         "Type": "種別",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -310,6 +310,43 @@ export class SW25Actor extends Actor {
       if (item.type == "skill") {
         if (item.name == systemData.frskill) {
           systemData.frbase = item.system.skillbase.intnef;
+          let skillLevel = item.system.skilllevel ? item.system.skilllevel : 0;
+
+          let fairyCount = 0;
+          if(systemData.attributes.fairy.earth){
+            fairyCount++;
+          }
+          if(systemData.attributes.fairy.water){
+            fairyCount++;
+          }
+          if(systemData.attributes.fairy.fire){
+            fairyCount++;
+          }
+          if(systemData.attributes.fairy.wind){
+            fairyCount++;
+          }
+          if(systemData.attributes.fairy.light){
+            fairyCount++;
+          }
+          if(systemData.attributes.fairy.dark){
+            fairyCount++;
+          }
+
+          const fairyRank = [0,1,2,4,5,6,8,9,10,12,13,14,15,15,15,15];
+          const fairyAllRank = [0,0,0,2,3,4,4,5,6,6,7,8,8,9,10,10];
+          const fairyExRank = [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5];
+
+          let fairyUseRank = "";
+          if(fairyCount < 4) {
+            fairyUseRank = fairyRank[skillLevel];
+          } else if (fairyCount == 4){
+            fairyUseRank = skillLevel;
+          } else if (fairyCount == 5){
+            fairyUseRank = fairyAllRank[skillLevel];
+          } else {
+            fairyUseRank = `${fairyAllRank[skillLevel]}/${fairyExRank[skillLevel]}`;
+          }
+          systemData.frRank = fairyUseRank;
         }
       }
     });

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -442,6 +442,8 @@ export class SW25Actor extends Actor {
     let totalmppmod = null;
     let totaldreduce = null;
     let totalmovemod = null;
+    let totalhpregenmod = null;
+    let totalmpregenmod = null;
     let totalvitres = null;
     let totalmndres = null;
     let totalinit = null;
@@ -527,6 +529,8 @@ export class SW25Actor extends Actor {
       { key:"system.attributes.efmppmod", target:"totalmppmod" },
       { key:"system.attributes.efdreduce", target:"totaldreduce" },
       { key:"system.attributes.move.efmovemod", target:"totalmovemod" },
+      { key:"system.attributes.turnend.hpregenmod", target:"totalhpregenmod" },
+      { key:"system.attributes.turnend.mpregenmod", target:"totalmpregenmod" },
       { key:"system.effect.vitres", target:"totalvitres" },
       { key:"system.effect.mndres", target:"totalmndres" },
       { key:"system.effect.init", target:"totalinit" },
@@ -645,6 +649,8 @@ export class SW25Actor extends Actor {
     systemData.totalmppmod = totalmppmod;
     systemData.totaldreduce = totaldreduce;
     systemData.totalmovemod = totalmovemod;
+    systemData.totalhpregenmod = totalhpregenmod;
+    systemData.totalmpregenmod = totalmpregenmod;
     systemData.totalvitres = totalvitres;
     systemData.totalmndres = totalmndres;
     systemData.totalinit = totalinit;
@@ -728,6 +734,8 @@ export class SW25Actor extends Actor {
     if (totalmppmod > 0) systemData.totalmppmod = "+" + totalmppmod;
     if (totaldreduce > 0) systemData.totaldreduce = "+" + totaldreduce;
     if (totalmovemod > 0) systemData.totalmovemod = "+" + totalmovemod;
+    if (totalhpregenmod > 0) systemData.totalhpregenmod = "+" + totalhpregenmod;
+    if (totalmpregenmod > 0) systemData.totalmpregenmod = "+" + totalmpregenmod;
     if (totalvitres > 0) systemData.totalvitres = "+" + totalvitres;
     if (totalmndres > 0) systemData.totalmndres = "+" + totalmndres;
     if (totalinit > 0) systemData.totalinit = "+" + totalinit;
@@ -1071,6 +1079,8 @@ export class SW25Actor extends Actor {
     let totalmppmod = null;
     let totaldreduce = null;
     let totalmovemod = null;
+    let totalhpregenmod = null;
+    let totalmpregenmod = null;
     let totalvitres = null;
     let totalmndres = null;
     let totalinit = null;
@@ -1151,6 +1161,8 @@ export class SW25Actor extends Actor {
       { key: "system.attributes.efmppmod", target: "totalmppmod" },
       { key: "system.attributes.efdreduce", target: "totaldreduce" },
       { key: "system.attributes.move.efmovemod", target: "totalmovemod" },
+      { key: "system.attributes.turnend.hpregenmod", target: "totalhpregenmod" },
+      { key: "system.attributes.turnend.mpregenmod", target: "totalmpregenmod" },
       { key: "system.effect.vitres", target: "totalvitres" },
       { key: "system.effect.mndres", target: "totalmndres" },
       { key: "system.effect.init", target: "totalinit" },
@@ -1264,6 +1276,8 @@ export class SW25Actor extends Actor {
     systemData.totalmppmod = totalmppmod;
     systemData.totaldreduce = totaldreduce;
     systemData.totalmovemod = totalmovemod;
+    systemData.totalhpregenmod = totalhpregenmod;
+    systemData.totalmpregenmod = totalmpregenmod;
     systemData.totalvitres = totalvitres;
     systemData.totalmndres = totalmndres;
     systemData.totalinit = totalinit;
@@ -1343,6 +1357,8 @@ export class SW25Actor extends Actor {
     if (totalmppmod > 0) systemData.totalmppmod = "+" + totalmppmod;
     if (totaldreduce > 0) systemData.totaldreduce = "+" + totaldreduce;
     if (totalmovemod > 0) systemData.totalmovemod = "+" + totalmovemod;
+    if (totalhpregenmod > 0) systemData.totalhpregenmod = "+" + totalhpregenmod;
+    if (totalmpregenmod > 0) systemData.totalmpregenmod = "+" + totalmpregenmod;
     if (totalvitres > 0) systemData.totalvitres = "+" + totalvitres;
     if (totalmndres > 0) systemData.totalmndres = "+" + totalmndres;
     if (totalinit > 0) systemData.totalinit = "+" + totalinit;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -508,7 +508,11 @@ export class SW25Actor extends Actor {
     let totalewckmod = null;
     let totalewpwmod = null;
     let totallootmod = null;
-
+    let totalfinechkmod = null;
+    let totalmovechkmod = null;
+    let totalobsechkmod = null;
+    let totalknowchkmod = null;
+    
     const processingRules = [
       { key:"system.attributes.efhitmod", target:"totalhitmod" },
       { key:"system.attributes.efdmod", target:"totaldmod" },
@@ -588,7 +592,11 @@ export class SW25Actor extends Actor {
       { key:"system.attributes.efatckmod", target:"totalatckmod" },
       { key:"system.attributes.efewckmod", target:"totalewckmod" },
       { key:"system.attributes.efewpwmod", target:"totalewpwmod" },
-      { key:"system.eflootmod", target:"totallootmod" }
+      { key:"system.eflootmod", target:"totallootmod" },
+      { key:"system.effect.package.fine", target:"totalfinechkmod" },
+      { key:"system.effect.package.move", target:"totalmovechkmod" },
+      { key:"system.effect.package.obse", target:"totalobsechkmod" },
+      { key:"system.effect.package.know", target:"totalknowchkmod" }
     ];
     let ruleMap = Object.fromEntries(
       processingRules.map((rule) => [rule.key, rule])
@@ -703,6 +711,10 @@ export class SW25Actor extends Actor {
     systemData.totalewckmod = totalewckmod;
     systemData.totalewpwmod = totalewpwmod;
     systemData.totallootmod = totallootmod;
+    systemData.totalfinechkmod = totalfinechkmod;
+    systemData.totalmovechkmod = totalmovechkmod;
+    systemData.totalobsechkmod = totalobsechkmod;
+    systemData.totalknowchkmod = totalknowchkmod;
     if (totalhitmod > 0) systemData.totalhitmod = "+" + totalhitmod;
     if (totaldmod > 0) systemData.totaldmod = "+" + totaldmod;
     if (totalcmod > 0) systemData.totalcmod = "+" + totalcmod;
@@ -772,6 +784,10 @@ export class SW25Actor extends Actor {
     if (totalewckmod > 0) systemData.totalewckmod = "+" + totalewckmod;
     if (totalewpwmod > 0) systemData.totalewpwmod = "+" + totalewpwmod;
     if (totallootmod > 0) systemData.totallootmod = "+" + totallootmod;
+    if (totalfinechkmod > 0) systemData.totalfinechkmod = "+" + totalfinechkmod;
+    if (totalmovechkmod > 0) systemData.totalmovechkmod = "+" + totalmovechkmod;
+    if (totalobsechkmod > 0) systemData.totalobsechkmod = "+" + totalobsechkmod;
+    if (totalknowchkmod > 0) systemData.totalknowchkmod = "+" + totalknowchkmod;
 
     // Set initiative formula
     systemData.initiativeFormula = "2d6";

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -390,6 +390,14 @@ export class SW25Item extends Item {
       }
       if (actorData.effect.allck)
         systemData.efallckmod = Number(actorData.effect.allck);
+      if (systemData.checkpackage == "fine")
+        systemData.efckmod += Number(actorData.effect.package.fine);
+      if (systemData.checkpackage == "move")
+        systemData.efckmod += Number(actorData.effect.package.move);
+      if (systemData.checkpackage == "obse")
+        systemData.efckmod += Number(actorData.effect.package.obse);
+      if (systemData.checkpackage == "know")
+        systemData.efckmod += Number(actorData.effect.package.know);
     }
 
     systemData.checkbase =

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -626,6 +626,7 @@ export class SW25Item extends Item {
     let checkabimod2 = 0;
     let checkabimod3 = 0;
     let powerabimod = 0;
+    let dedicatedDex = (itemData.type === "weapon" && itemData.system.dedicated) ? 2 : 0;
     if (actor.type == "character") {
       if (systemData.checkabi == "dex")
         checkabimod = Math.floor(
@@ -633,7 +634,8 @@ export class SW25Item extends Item {
             actorData.abilities.dex.valuebase +
             actorData.abilities.dex.valuegrowth +
             actorData.abilities.dex.valuemodify +
-            actorData.abilities.dex.efvaluemodify) /
+            actorData.abilities.dex.efvaluemodify +
+            dedicatedDex) /
             6 +
             Number(actorData.abilities.dex.efmodify)
         );
@@ -1613,6 +1615,8 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
+    const actorData = itemData.actor.system;
+    const actoritemData = itemData.actor.items;
 
     if (systemData.type != "-") {
       const i18ntype =
@@ -1740,6 +1744,8 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
+    const actorData = itemData.actor.system;
+    const actoritemData = itemData.actor.items;
 
     if (systemData.category != "-") {
       const i18ncat =
@@ -2026,6 +2032,8 @@ export class SW25Item extends Item {
 
     // Make modifications to data here. For example:
     const systemData = itemData.system;
+    const actorData = itemData.actor.system;
+    const actoritemData = itemData.actor.items;
 
     if (systemData.type != "-") {
       const i18ntype =

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -390,14 +390,16 @@ export class SW25Item extends Item {
       }
       if (actorData.effect.allck)
         systemData.efallckmod = Number(actorData.effect.allck);
-      if (systemData.checkpackage == "fine")
-        systemData.efckmod += Number(actorData.effect.package.fine);
-      if (systemData.checkpackage == "move")
-        systemData.efckmod += Number(actorData.effect.package.move);
-      if (systemData.checkpackage == "obse")
-        systemData.efckmod += Number(actorData.effect.package.obse);
-      if (systemData.checkpackage == "know")
-        systemData.efckmod += Number(actorData.effect.package.know);
+
+      if (systemData.checkpackage == "fine"){
+        systemData.efckmod += actorData.effect.package?.fine ? Number(actorData.effect.package?.fine) : 0;
+      } else if (systemData.checkpackage == "move"){
+        systemData.efckmod += actorData.effect.package?.move ? Number(actorData.effect.package?.move) : 0;
+      } else if (systemData.checkpackage == "obse"){
+        systemData.efckmod += actorData.effect.package?.obse ? Number(actorData.effect.package?.obse) : 0;
+      } else if (systemData.checkpackage == "know"){
+        systemData.efckmod += actorData.effect.package?.know ? Number(actorData.effect.package?.know) : 0;
+      }
     }
 
     systemData.checkbase =

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -626,7 +626,8 @@ export class SW25Item extends Item {
     let checkabimod2 = 0;
     let checkabimod3 = 0;
     let powerabimod = 0;
-    let dedicatedDex = (itemData.type === "weapon" && itemData.system.dedicated) ? 2 : 0;
+    let dedicatedDex =
+      itemData.type === "weapon" && itemData.system.dedicated ? 2 : 0;
     if (actor.type == "character") {
       if (systemData.checkabi == "dex")
         checkabimod = Math.floor(
@@ -1729,6 +1730,25 @@ export class SW25Item extends Item {
         }
         */
       }
+    }
+
+    // resourcetype check.
+    if (systemData.resource?.type == "note") {
+      systemData.resource.isNote = true;
+    } else if (systemData.resource?.type == "material") {
+      systemData.resource.isMaterial = true;
+    } else if (systemData?.resource.type == "lifeline") {
+      systemData.resource.isLifeline = true;
+    } else if (systemData?.resource.type == "tacspower") {
+      systemData.resource.isTacsPower = true;
+    } else if (systemData?.resource.type == "abyssex") {
+      systemData.resource.isAbyssEx = true;
+    } else {
+      systemData.resource.isNote = false;
+      systemData.resource.isMaterial = false;
+      systemData.resource.isLifeline = false;
+      systemData.resource.isTacsPower = false;
+      systemData.resource.isAbyssEx = false;
     }
 
     // Sheet refresh

--- a/module/helpers/chatbutton.mjs
+++ b/module/helpers/chatbutton.mjs
@@ -1741,7 +1741,7 @@ export async function chatButton(chatMessage, buttonType) {
       }
     
       if (successCount > 0) {
-        if(targetValues.size > 1){
+        if(targetValues.length > 1){
           resultText = `<span class="success"> ${successCount} ${game.i18n.localize("SW25.Success")} ▶ </span>`;
         } else {
           resultText = `<span class="success"> ${game.i18n.localize("SW25.Success")} ▶ </span>`;

--- a/module/helpers/chatbutton.mjs
+++ b/module/helpers/chatbutton.mjs
@@ -1709,8 +1709,8 @@ export async function chatButton(chatMessage, buttonType) {
       label = `${game.i18n.localize(
         "SW25.StraightRoll"
       )} - ${checkName} (${game.i18n.localize("SW25.Check")})`;
+    label += flags.targetValue ? "/" + flags.targetValue : "";
 
-    let judge = false;
     let resultText = "";
     let fumble =
       roll.terms[0].results[0].result == 1 &&
@@ -1718,18 +1718,39 @@ export async function chatButton(chatMessage, buttonType) {
     let critical =
       roll.terms[0].results[0].result == 6 &&
       roll.terms[0].results[1].result == 6;
+
+    let targetValues;
+
     if (flags.targetValue) {
-      if (roll.total >= parseInt(flags.targetValue, 10)) judge = true;
-      if (judge) {
-        resultText = `<span class="success"> ${game.i18n.localize(
-          "SW25.Success"
-        )} ▶ </span>`;
+      if (typeof flags.targetValue === "number") {
+        targetValues = [flags.targetValue];
+      } else if (typeof flags.targetValue === "string") {
+        targetValues = flags.targetValue.match(/[/,／， 　]/) 
+         ? flags.targetValue.split(/[/,／， 　]/).map(v => parseInt(v, 10)).filter(v => !isNaN(v)) 
+         : [parseInt(flags.targetValue, 10)].filter(v => !isNaN(v));
       } else {
-        resultText = `<span class="failed"> ${game.i18n.localize(
-          "SW25.Failed"
-        )} ▶ </span>`;
+        targetValues = [];
+      }
+
+      let successCount = 0;
+    
+      for (let target of targetValues) {
+        if (roll.total >= target) {
+          successCount++;
+        }
+      }
+    
+      if (successCount > 0) {
+        if(targetValues.size > 1){
+          resultText = `<span class="success"> ${successCount} ${game.i18n.localize("SW25.Success")} ▶ </span>`;
+        } else {
+          resultText = `<span class="success"> ${game.i18n.localize("SW25.Success")} ▶ </span>`;
+        }
+      } else {
+        resultText = `<span class="failed"> ${game.i18n.localize("SW25.Failed")} ▶ </span>`;
       }
     }
+
     if (critical) {
       resultText = `<span class="success">${game.i18n.localize(
         "SW25.Auto"

--- a/module/helpers/rollrequest.mjs
+++ b/module/helpers/rollrequest.mjs
@@ -80,28 +80,23 @@ export async function rollreq() {
                   "SW25.Attributes.Advlevel"
                 )}${abi}`;
             }
+            let difficulty = targetValue ? game.i18n.localize("SW25.Difficulty") : "";
 
-            if (message && !targetValue) chatData.content = `${message}`;
-            if (!message && targetValue)
-              chatData.content = `<b>${game.i18n.localize(
-                "SW25.Difficulty"
-              )} : ${targetValue}</b>`;
-            if (message && targetValue)
-              chatData.content = `${message} <b>(${game.i18n.localize(
-                "SW25.Difficulty"
-              )} : ${targetValue}</b>)`;
-
+            let mod = "";
             if (modifier) {
-              let mod = modifier;
-              if (mod > 0) mod = `+${modifier}`;
-              chatData.content += `<div><button class="buttonclick" data-buttontype="buttonrollreq">${name} ${game.i18n.localize(
-                "SW25.Check"
-              )} (${mod})</button></div>`;
-            } else
-              chatData.content += `<div><button class="buttonclick" data-buttontype="buttonrollreq">${name} ${game.i18n.localize(
-                "SW25.Check"
-              )}</button></div>`;
+              mod = modifier > 0 ? `+${modifier}` : modifier;
+            }
 
+            chatData.content = await renderTemplate(
+              "systems/sw25/templates/roll/rollreq-card.hbs",
+              {
+                checkName: name,
+                message: message,
+                difficulty: difficulty,
+                targetValue: targetValue,
+                mod: mod,
+              }
+            );
             ChatMessage.create(chatData);
           },
         },

--- a/module/sheets/active-effect-config.mjs
+++ b/module/sheets/active-effect-config.mjs
@@ -49,6 +49,10 @@ export class SW25ActiveEffectConfig extends ActiveEffectConfig {
         case "system.effect.allck":
         case "system.effect.allsk":
         case "system.eflootmod":
+        case "system.effect.package.fine":
+        case "system.effect.package.move":
+        case "system.effect.package.obse":
+        case "system.effect.package.know":
           change.keyClassification = "check";
           change.keyname = change.key.replace(/^system\./, "");
           break;

--- a/module/sheets/active-effect-config.mjs
+++ b/module/sheets/active-effect-config.mjs
@@ -39,7 +39,9 @@ export class SW25ActiveEffectConfig extends ActiveEffectConfig {
         case "system.attributes.efmppmod":
         case "system.attributes.efdreduce":
         case "system.attributes.move.efmovemod":
-          change.keyClassification = "battle";
+        case "system.attributes.turnend.hpregenmod":
+        case "system.attributes.turnend.mpregenmod":
+              change.keyClassification = "battle";
           change.keyname = change.key.replace(/^system\./, "");
           break;
         case "system.effect.vitres":

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1265,8 +1265,8 @@ export class SW25ActorSheet extends ActorSheet {
     const action = event.currentTarget.dataset.action;
     const input = event.currentTarget.parentElement.querySelector("input");
 
-    if (action === "decrease") input.valueAsNumber -= 1;
-    else if (action === "increase") input.valueAsNumber += 1;
+    if (action === "decrease") (isNaN(input.valueAsNumber) || !input.valueAsNumber) ? input.valueAsNumber = -1 : input.valueAsNumber -= 1;
+    else if (action === "increase") (isNaN(input.valueAsNumber) || !input.valueAsNumber) ? input.valueAsNumber = 1 : input.valueAsNumber += 1;
 
     this.submit();
   }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -158,6 +158,25 @@ export class SW25ActorSheet extends ActorSheet {
     const actionsd28 = [];
     const actionsd49 = [];
     const actionsd610 = [];
+    const notes = [];
+    const materials = {
+      red: { b: [], a: [], s: [], ss: [] },
+      green: { b: [], a: [], s: [], ss: [] },
+      black: { b: [], a: [], s: [], ss: [] },
+      white: { b: [], a: [], s: [], ss: [] },
+      gold: { b: [], a: [], s: [], ss: [] },
+    };
+    const lifelines = [];
+    const tacspowers = [];
+    const abyssexs = [];
+    let materialshow = {
+      all: false,
+      red: false,
+      green: false,
+      black: false,
+      white: false,
+      gold: false,
+    };
 
     // Iterate through items, allocating to containers
     for (let i of context.items) {
@@ -175,7 +194,29 @@ export class SW25ActorSheet extends ActorSheet {
       }
       // Append to resource.
       if (i.type === "resource") {
-        resources.push(i);
+        if (
+          i.system?.resource?.type == null ||
+          i.system?.resource?.type == "none" ||
+          !i.system?.resource?.isNotBattle
+        ) {
+          resources.push(i);
+        }
+
+        if (i.system?.resource?.type == "note") {
+          notes.push(i);
+        } else if (i.system?.resource?.type == "material") {
+          let materialtype = i.system?.resource?.materialtype;
+          let materialrank = i.system?.resource?.materialrank;
+          materials[materialtype][materialrank].push(i);
+          materialshow.all = true;
+          materialshow[materialtype] = true;
+        } else if (i.system?.resource?.type == "lifeline") {
+          lifelines.push(i);
+        } else if (i.system?.resource?.type == "tacspower") {
+          tacspowers.push(i);
+        } else if (i.system?.resource?.type == "abyssex") {
+          abyssexs.push(i);
+        }
       }
       // Append to weapon.
       else if (i.type === "weapon") {
@@ -526,6 +567,16 @@ export class SW25ActorSheet extends ActorSheet {
     context.actionsd28 = actionsd28;
     context.actionsd49 = actionsd49;
     context.actionsd610 = actionsd610;
+    context.notes = notes;
+    context.materials = materials;
+    context.lifelines = lifelines;
+    context.tacspowers = tacspowers;
+    context.abyssexs = abyssexs;
+    context.noteshow = notes.length > 0;
+    context.materialshow = materialshow;
+    context.lifelineshow = lifelines.length > 0;
+    context.tacspowershow = tacspowers.length > 0;
+    context.abyssexshow = abyssexs.length > 0;
   }
 
   /* -------------------------------------------- */
@@ -587,6 +638,12 @@ export class SW25ActorSheet extends ActorSheet {
     // Loot roll.
     html.on("click", ".lootrollable", this._onLootRoll.bind(this));
 
+    // use Phasearea.
+    html.on("click", ".usephasearea", this._onUsePhasearea.bind(this));
+
+    // Material card cost.
+    html.on("click", ".materialcardcost", this._onMaterialcardCost.bind(this));
+
     // Popularity roll.
     html.on("click", ".popularityrollable", this._onPopularityRoll.bind(this));
 
@@ -632,6 +689,16 @@ export class SW25ActorSheet extends ActorSheet {
 
     // Drag action item to table
     html.find(`.actiontable`).on("drop", this._onActionTableDrag.bind(this));
+
+    // Fairy contract check
+    html.find(".fairy-contract").on("click", async (ev) => {
+      const target = ev.currentTarget;
+      const dataPath = target.dataset.path;
+      const currentState = getProperty(this.actor, dataPath) || false;
+
+      await this.actor.update({ [dataPath]: !currentState });
+      target.classList.toggle("checked", !currentState);
+    });
   }
 
   /**
@@ -1252,11 +1319,17 @@ export class SW25ActorSheet extends ActorSheet {
       : game.i18n.localize("SW25.Monster.Unidentifiedmon");
     monsterName += `(${this.actor.system.type})`;
     targetValue = this.actor.system.popularity;
-    targetValue += Number.isFinite(this.actor.system.weakpoint) ? "/" + this.actor.system.weakpoint : "";
+    targetValue += Number.isFinite(this.actor.system.weakpoint)
+      ? "/" + this.actor.system.weakpoint
+      : "";
 
-    let message = `${game.i18n.localize("SW25.Monster.Popularity")}/${game.i18n.localize("SW25.Monster.Weakpoint")}`;
+    let message = `${game.i18n.localize(
+      "SW25.Monster.Popularity"
+    )}/${game.i18n.localize("SW25.Monster.Weakpoint")}`;
 
-    const speaker = isView ? ChatMessage.getSpeaker({ actor: this.actor }) : ChatMessage.getSpeaker({ alias: "Gamemaster" });
+    const speaker = isView
+      ? ChatMessage.getSpeaker({ actor: this.actor })
+      : ChatMessage.getSpeaker({ alias: "Gamemaster" });
 
     let chatData = {
       speaker: speaker,
@@ -1310,7 +1383,9 @@ export class SW25ActorSheet extends ActorSheet {
     targetValue = this.actor.system.preemptive;
     let message = game.i18n.localize("SW25.Monster.Preemptive");
 
-    const speaker = isView ? ChatMessage.getSpeaker({ actor: this.actor }) : ChatMessage.getSpeaker({ alias: "Gamemaster" });
+    const speaker = isView
+      ? ChatMessage.getSpeaker({ actor: this.actor })
+      : ChatMessage.getSpeaker({ alias: "Gamemaster" });
 
     let chatData = {
       speaker: speaker,
@@ -1748,5 +1823,417 @@ export class SW25ActorSheet extends ActorSheet {
       ]);
       await createdItem[0].update(updatedData);
     }
+  }
+
+  async _selectApplyTarget(event, item, targetEffects, orgActor, orgId) {
+    const tokens = canvas.tokens.placeables;
+
+    if (tokens.length === 0) {
+      return ui.notifications.warn(game.i18n.localize("SW25.NotTokenwarn"));
+    }
+
+    const categories = {
+      friendly: [],
+      neutral: [],
+      hostile: [],
+    };
+
+    tokens.forEach((token) => {
+      switch (token.document.disposition) {
+        case 1:
+          categories.friendly.push(token);
+          break;
+        case 0:
+          categories.neutral.push(token);
+          break;
+        case -1:
+          categories.hostile.push(token);
+          break;
+      }
+    });
+
+    for (const key in categories) {
+      categories[key].sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    const createCategoryBox = (category, title, categoryId) => {
+      let box = `<fieldset class="target-select">
+        <legend id="${categoryId}-toggle" style="cursor: pointer;">
+          <span class="selectable">${title}</span>
+        </legend>`;
+      category.forEach((token) => {
+        box += `
+          <div>
+            <input type="checkbox" id="token-${token.id}" name="${categoryId}" value="${token.id}" />
+            <label for="token-${token.id}" style="font-weight: normal;">${token.name}</label>
+          </div>`;
+      });
+      box += `</fieldset>`;
+      return box;
+    };
+
+    const content = `
+      <div style="width: 100%;">
+        ${createCategoryBox(
+          categories.friendly,
+          game.i18n.localize("SW25.Disposition.Friendly"),
+          "friendly"
+        )}
+        ${createCategoryBox(
+          categories.neutral,
+          game.i18n.localize("SW25.Disposition.Neutral"),
+          "neutral"
+        )}
+        ${createCategoryBox(
+          categories.hostile,
+          game.i18n.localize("SW25.Disposition.Hostile"),
+          "hostile"
+        )}
+      </div>`;
+
+    const dialog = new Dialog({
+      title: game.i18n.localize("SW25.TargetSelect") + `(${item.name})`,
+      content: content,
+      buttons: {
+        process: {
+          label: game.i18n.localize("SW25.Item.EffectB"),
+          callback: (html) => {
+            const selectedIds = html
+              .find('input[type="checkbox"]:checked')
+              .map((_, el) => el.value)
+              .get();
+
+            if (selectedIds.length === 0) {
+              return ui.notifications.warn(
+                game.i18n.localize("SW25.Notargetwarn")
+              );
+            }
+
+            const selectedTokens = canvas.tokens.placeables.filter((token) =>
+              selectedIds.includes(token.id)
+            );
+            const targetTokenId = Array.from(
+              selectedTokens,
+              (target) => target.id
+            );
+
+            if (game.user.isGM) {
+              selectedTokens.forEach((targetActor) => {
+                targetEffects.forEach((effect) => {
+                  const transferEffect = duplicate(effect);
+                  transferEffect.disabled = false;
+                  transferEffect.sourceName = orgActor;
+                  transferEffect.flags.sourceName = orgActor;
+                  transferEffect.flags.sourceId = `Actor.${orgId}`;
+                  targetActor.actor.createEmbeddedDocuments("ActiveEffect", [
+                    transferEffect,
+                  ]);
+                });
+              });
+            } else {
+              console.log(targetTokenId);
+              console.log(targetEffects);
+              game.socket.emit("system.sw25", {
+                method: "applyEffect",
+                targetTokens: targetTokenId,
+                targetEffects: targetEffects,
+                orgActor: orgActor,
+                orgId: orgId,
+              });
+            }
+          },
+        },
+        cancel: {
+          label: game.i18n.localize("SW25.Item.Spell.Cancel"),
+        },
+      },
+      default: "cancel",
+    });
+
+    dialog.render(true);
+
+    Hooks.once("renderDialog", (app, html) => {
+      const addToggleHandler = (categoryId) => {
+        const toggle = html.find(`#${categoryId}-toggle`);
+        const checkboxes = html.find(`input[name="${categoryId}"]`);
+
+        toggle.on("click", () => {
+          const allChecked = checkboxes.toArray().every((cb) => cb.checked);
+          checkboxes.prop("checked", !allChecked).trigger("change");
+        });
+
+        checkboxes.on("change", (event) => {
+          const checkbox = $(event.currentTarget);
+          const label = checkbox.next("label");
+          label.css("font-weight", checkbox.is(":checked") ? "bold" : "normal");
+        });
+      };
+
+      addToggleHandler("friendly");
+      addToggleHandler("neutral");
+      addToggleHandler("hostile");
+
+      html[0].style.width = "500px";
+    });
+  }
+
+  async _onUsePhasearea(event) {
+    event.preventDefault();
+    const selectedTokens = canvas.tokens.controlled;
+    if (selectedTokens.length === 0) {
+      ui.notifications.warn(game.i18n.localize("SW25.Noselectwarn"));
+      return;
+    } else if (selectedTokens.length > 1) {
+      ui.notifications.warn(game.i18n.localize("SW25.Multiselectwarn"));
+      return;
+    }
+
+    const changeItem = $(event.currentTarget);
+    const item = this.actor.items.get(
+      changeItem.parents(".item")[0].dataset.itemId
+    );
+    let cost = item.system.mincost ? item.system.mincost : 0;
+
+    if (item.system.maxcost && item.system.mincost != item.system.maxcost) {
+      this._inputUsePhaseareaCost(item);
+    } else {
+      this._applyPhasearea(item, cost);
+    }
+  }
+
+  async _applyPhasearea(item, cost) {
+    const selectedTokens = canvas.tokens.controlled;
+    if (selectedTokens.length === 0) {
+      ui.notifications.warn(game.i18n.localize("SW25.Noselectwarn"));
+      return;
+    } else if (selectedTokens.length > 1) {
+      ui.notifications.warn(game.i18n.localize("SW25.Multiselectwarn"));
+      return;
+    }
+
+    const orgActor = this.actor.name;
+    const orgId = this.actor._id;
+    const name =
+      item.name +
+      game.i18n.localize("SW25.Use") +
+      " " +
+      cost +
+      game.i18n.localize("SW25.Item.Phasearea.Point");
+    let effects = [
+      {
+        name: name,
+        img: item.img,
+        origin: "Item." + item._id,
+        disabled: false,
+        changes: [],
+        description: item.system.description,
+        transfer: false,
+        statuses: [],
+        flags: {
+          sourceName: orgActor,
+          sourceId: `Actor.${orgId}`,
+        },
+        tint: null,
+      },
+    ];
+
+    let lifeline = "";
+    if (item.system.type == "ten") {
+      lifeline = "Ten";
+    } else if (item.system.type == "chi") {
+      lifeline = "Chi";
+    } else if (item.system.type == "jin") {
+      lifeline = "Jin";
+    }
+
+    let resource = this.actor.items.find(i =>
+      i.type === "resource" &&
+      i.system?.resource?.type === "lifeline" &&
+      i.system?.resource?.lifelinetype === item.system.type
+    );
+
+    if (!resource) {
+      ui.notifications.warn(game.i18n.localize("SW25.NotResource") + ":" + game.i18n.localize(`SW25.Item.Phasearea.${lifeline}`));
+    } else {
+      let oldVal = resource.system.quantity ? resource.system.quantity : 0;
+      let newVal = oldVal - cost;
+
+      await resource.update({ "system.quantity": newVal });
+    }
+
+    if (item.system.type == "ten") {
+      let val = this.actor.system.attributes.qi.heaven.value - cost;
+      this.actor.update({
+        "system.attributes.qi.heaven.value": val,
+      });
+    } else if (item.system.type == "chi") {
+      let val = this.actor.system.attributes.qi.earth.value - cost;
+      this.actor.update({
+        "system.attributes.qi.earth.value": val,
+      });
+    } else if (item.system.type == "jin") {
+      let val = this.actor.system.attributes.qi.spirit.value - cost;
+      this.actor.update({
+        "system.attributes.qi.spirit.value": val,
+      });
+    }
+
+    // Apply
+    if (game.user.isGM) {
+      selectedTokens[0].actor.createEmbeddedDocuments("ActiveEffect", effects);
+    } else {
+      const targetTokenId = Array.from(selectedTokens, (target) => target.id);
+      game.socket.emit("system.sw25", {
+        method: "applyEffect",
+        targetTokens: targetTokenId,
+        targetEffects: effects,
+        orgActor: orgActor,
+        orgId: orgId,
+      });
+    }
+
+    // Chat message
+    const speaker = ChatMessage.getSpeaker({ actor: this.actor });
+    let label = game.i18n.localize("SW25.Effectslong");
+    let chatActorName = ">>> " + selectedTokens[0].actor.name + "<br>";
+    let chatEffectName = effects[0].name + game.i18n.localize(`SW25.Item.Phasearea.${lifeline}`) + "<br>";
+
+    let chatData = {
+      speaker: speaker,
+      flavor: label,
+    };
+    chatData.content = await renderTemplate(
+      "systems/sw25/templates/roll/effect-apply.hbs",
+      {
+        targetActorName: chatActorName,
+        transferEffectName: chatEffectName,
+      }
+    );
+
+    ChatMessage.create(chatData);
+  }
+
+  async _inputUsePhaseareaCost(item) {
+    const title = game.i18n.localize("SW25.InputPhaseareaPoint");
+    new Dialog({
+      title: `${title} (${item.name})`,
+      content: `
+        <form>
+          <div class="form-group">
+            <label for="number">${title} (${item.system.mincost}-${item.system.maxcost})</label>
+          </div>
+          <div class="form-group">
+            <input id="number" name="number" type="number" value="0" />
+          </div>
+        </form>
+      `,
+      buttons: {
+        ok: {
+          label: game.i18n.localize("SW25.Use"),
+          callback: (html) => {
+            const cost = parseInt(html.find("#number").val());
+            if (isNaN(cost)) {
+              ui.notifications.error(
+                game.i18n.localize("SW25.Item.Spell.Cancel")
+              );
+              return;
+            }
+            this._applyPhasearea(item, cost);
+          },
+        },
+        cancel: {
+          label: game.i18n.localize("SW25.Item.Spell.Cancel"),
+        },
+      },
+      default: "ok",
+    }).render(true);
+  }
+
+  async _onMaterialcardCost(event) {
+    event.preventDefault();
+    const selectedTokens = canvas.tokens.controlled;
+    if (selectedTokens.length === 0) {
+      ui.notifications.warn(game.i18n.localize("SW25.Noselectwarn"));
+      return;
+    } else if (selectedTokens.length > 1) {
+      ui.notifications.warn(game.i18n.localize("SW25.Multiselectwarn"));
+      return;
+    }
+
+    const changeItem = $(event.currentTarget);
+    const item = this.actor.items.get(
+      changeItem.parents(".item")[0].dataset.itemId
+    );
+
+    const useRank = event.target.textContent.trim().toLowerCase();
+    let update = {};
+    const cards = [
+      { color: "red", mark: "fa-paw" },
+      { color: "green", mark: "fa-leaf" },
+      { color: "black", mark: "fa-gem" },
+      { color: "white", mark: "fa-heart" },
+      { color: "gold", mark: "fa-sun" },
+    ];
+    let message = `${item.name}<br>`;
+    
+    for (let card of cards) {
+      if(!isNaN(item.system[card.color]) && item.system[card.color] <= 0){
+        continue;
+      } 
+
+      let resource = this.actor.items.find(i =>
+          i.type === "resource" &&
+          i.system?.resource?.type === "material" &&
+          i.system?.resource?.materialtype === card.color &&
+          i.system?.resource?.materialrank === useRank
+      );
+
+      let cardCap =
+        card.color.charAt(0).toUpperCase() +
+        card.color.slice(1).toLowerCase();
+      if (!resource) {
+        message +=
+          `<div class="materialcard" style="text-align:center;"><div class="${card.color}"><i class="fa-solid ${card.mark}"></i>` +
+          game.i18n.localize(`SW25.Item.Alchemytech.${cardCap}`) +
+          event.target.textContent.trim() +
+          `(${item.system[card.color]})` +
+          ` ... <span style="font-size:1.5em">` +
+          game.i18n.localize(`SW25.NotResource`) +
+          `</span></div></div>`;
+      } else {
+        let oldVal = resource.system.quantity ? resource.system.quantity : 0;
+        let newVal = oldVal - item.system[card.color];
+
+        message +=
+          `<div class="materialcard" style="text-align:center;"><div class="${card.color}"><i class="fa-solid ${card.mark}"></i>` +
+          game.i18n.localize(`SW25.Item.Alchemytech.${cardCap}`) +
+          event.target.textContent.trim() +
+          `(${item.system[card.color]})` +
+          ` ... <span style="font-size:1.5em">${oldVal} -> ${newVal}</span></div></div>`;
+
+        await resource.update({ "system.quantity": newVal });
+      }
+    }
+
+    this.actor.update(update);
+
+    // Chat message
+    const speaker = ChatMessage.getSpeaker({ actor: this.actor });
+    let label =
+      game.i18n.localize("SW25.Item.Alchemytech.MaterialCard") +
+      game.i18n.localize("SW25.Cost");
+
+    let chatData = {
+      speaker: speaker,
+      flavor: label,
+    };
+    chatData.content = await renderTemplate(
+      "systems/sw25/templates/roll/card-apply.hbs",
+      {
+        message: message,
+      }
+    );
+
+    ChatMessage.create(chatData);
   }
 }

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -556,7 +556,17 @@
         <div class="grid grid-12col">
           <span class="spelllist-label resource-label-l grid-span-2">{{localize "SW25.Item.Spell.Fairy"}}</span>
           <span class="rollable resource-label-l grid-span-2" data-roll="2d6+{{system.attributes.frcast}}" data-label="{{localize "SW25.Item.Spell.Fairy"}}" data-pt="" data-spell="on" data-apply="-" data-checktype="">{{localize "SW25.Attributes.Magicpower"}} : {{system.attributes.frpower}}</span>
-          <span class="grid-span-2"></span>
+          <span class="grid-span-2">
+            <div class="fairy-checkbox">
+              <label class="fairy-contract f-earth {{#if system.attributes.fairy.earth}}checked{{/if}}" data-path="system.attributes.fairy.earth">{{localize "SW25.Item.Spell.FairyContract.Earth"}}</label>
+              <label class="fairy-contract f-water {{#if system.attributes.fairy.water}}checked{{/if}}" data-path="system.attributes.fairy.water">{{localize "SW25.Item.Spell.FairyContract.Water"}}</label>
+              <label class="fairy-contract f-fire {{#if system.attributes.fairy.fire}}checked{{/if}}" data-path="system.attributes.fairy.fire">{{localize "SW25.Item.Spell.FairyContract.Fire"}}</label>
+              <label class="fairy-contract f-wind {{#if system.attributes.fairy.wind}}checked{{/if}}" data-path="system.attributes.fairy.wind">{{localize "SW25.Item.Spell.FairyContract.Wind"}}</label>
+              <label class="fairy-contract f-light {{#if system.attributes.fairy.light}}checked{{/if}}" data-path="system.attributes.fairy.light">{{localize "SW25.Item.Spell.FairyContract.Light"}}</label>
+              <label class="fairy-contract f-dark {{#if system.attributes.fairy.dark}}checked{{/if}}" data-path="system.attributes.fairy.dark">{{localize "SW25.Item.Spell.FairyContract.Dark"}}</label>
+            </div>
+            <span class="fairy-rank">{{localize "SW25.Item.Spell.FairyContract.Rank"}}:{{system.frRank}}</span>
+          </span>
           <span class="grid-span-4" style="text-align: right;">
             <select name="system.frskill">
               {{#select system.frskill}}

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -756,6 +756,10 @@
           {{#if system.totalewckmod}}<div><b>{{localize "TYPES.Item.essenceweave"}} / {{localize "SW25.Effect.Force"}}: {{system.totalewckmod}}</b></div>{{/if}}
           {{#if system.totalewpwmod}}<div><b>{{localize "TYPES.Item.essenceweave"}} / {{localize "SW25.Effect.MPower"}}: {{system.totalewpwmod}}</b></div>{{/if}}
           {{#if system.totallootmod}}<div><b>{{localize "SW25.Monster.Loot"}}: {{system.totallootmod}}</b></div>{{/if}}
+          {{#if system.totalfinechkmod}}<div><b>{{localize "SW25.Item.Check.Packages.Finesse"}}{{localize "SW25.Check"}}: {{system.totalfinechkmod}}</b></div>{{/if}}
+          {{#if system.totalmovechkmod}}<div><b>{{localize "SW25.Item.Check.Packages.Movement"}}{{localize "SW25.Check"}}: {{system.totalmovechkmod}}</b></div>{{/if}}
+          {{#if system.totalobsechkmod}}<div><b>{{localize "SW25.Item.Check.Packages.Observation"}}{{localize "SW25.Check"}}: {{system.totalobsechkmod}}</b></div>{{/if}}
+          {{#if system.totalknowchkmod}}<div><b>{{localize "SW25.Item.Check.Packages.Knowledge"}}{{localize "SW25.Check"}}: {{system.totalknowchkmod}}</b></div>{{/if}}
         </div>
       </div>
       <div>

--- a/templates/actor/actor-character-sheet.hbs
+++ b/templates/actor/actor-character-sheet.hbs
@@ -531,7 +531,7 @@
         <div class="grid grid-12col">
           <span class="spelllist-label resource-label-l grid-span-2">{{localize "SW25.Item.Spell.Magitech"}}</span>
           <span class="rollable resource-label-l grid-span-2" data-roll="2d6+{{system.attributes.mtcast}}" data-label="{{localize "SW25.Item.Spell.Magitech"}}" data-pt="" data-spell="on" data-apply="-" data-checktype="">{{localize "SW25.Attributes.Magicpower"}} : {{system.attributes.mtpower}}</span>
-          <span class="grid-span-2"></span>
+          <span class="rollable resource-label-l grid-span-2" style="text-align: center;" data-resusequantity={{system.resusequantity}} data-resuse="{{system.resuse}}" data-roll="{{system.itemhitformula}}+{{system.itemhitbase}}" data-label="{{system.itemname}} ({{localize "SW25.Item.Weapon.Hit"}})" data-pt="{{system.itempowertable}}" data-apply="{{system.itemapplycheck}}" data-checktype="{{system.itemchecktype}}">{{localize "SW25.Item.Weapon.Hit"}} : {{system.itemhitbase}}</span>
           <span class="grid-span-4" style="text-align: right;">
             <select name="system.mtskill">
               {{#select system.mtskill}}
@@ -690,6 +690,8 @@
           {{#if system.totalmppmod}}<div><b>{{localize "SW25.Effect.MppMod"}}: {{system.totalmppmod}}</b></div>{{/if}}
           {{#if system.totaldreduce}}<div><b>{{localize "SW25.Effect.Dreduce"}}: {{system.totaldreduce}}</b></div>{{/if}}
           {{#if system.totalmovemod}}<div><b>{{localize "SW25.Effect.MoveMod"}}: {{system.totalmovemod}}</b></div>{{/if}}
+          {{#if system.totalhpregenmod}}<div><b>{{localize "SW25.Effect.HpregenMod"}}: {{system.totalhpregenmod}}</b></div>{{/if}}
+          {{#if system.totalmpregenmod}}<div><b>{{localize "SW25.Effect.MpregenMod"}}: {{system.totalmpregenmod}}</b></div>{{/if}}
           {{#if system.totalvitres}}<div><b>{{localize "SW25.Config.ResVit"}}: {{system.totalvitres}}</b></div>{{/if}}
           {{#if system.totalmndres}}<div><b>{{localize "SW25.Config.ResMnd"}}: {{system.totalmndres}}</b></div>{{/if}}
           {{#if system.totalinit}}<div><b>{{localize "SW25.Config.Init"}}: {{system.totalinit}}</b></div>{{/if}}

--- a/templates/actor/actor-monster-sheet.hbs
+++ b/templates/actor/actor-monster-sheet.hbs
@@ -75,7 +75,7 @@
             </div>
           </div>
           <div class="flexrow">
-            <div class="monster-popularity">
+            <div class="monster-popularity popularityrollable">
               <span class="monster-label monster-small">{{localize "SW25.Monster.Popularity"}}/{{localize "SW25.Monster.Weakpoint"}} : </span>
               <span class="monster-small">{{system.popularity}}/{{system.weakpoint}}</span>
             </div>
@@ -85,7 +85,7 @@
             </div>
           </div>
           <div class="flexrow">
-            <div class="monster-preemptive">
+            <div class="monster-preemptive preemptiverollable">
               <span class="monster-label monster-small">{{localize "SW25.Monster.Preemptive"}}: </span>
               <span class="monster-small">{{system.preemptive}}</span>
             </div>

--- a/templates/actor/parts/actor-alchemytechs.hbs
+++ b/templates/actor/parts/actor-alchemytechs.hbs
@@ -1,7 +1,511 @@
 <ol class='items-list'>
+  {{#if materialshow.all}}
+    <div class='item flexrow items-header'>
+      <div class='item-name'>{{localize "TYPES.Item.alchemytech"}}</div>
+    </div>
+    <div class='item flexrow'>
+      <div class='items-list materialcard'>
+        <div class='item flexrow items-header spelllist-label'>
+          <div class='item-name'>{{localize "SW25.Item.Alchemytech.MaterialCard"}}</div>
+          <div class='quantity'>B</div>
+          <div class='quantity'>A</div>
+          <div class='quantity'>S</div>
+          <div class='quantity'>SS</div>
+        </div>
+        <div class="spelllist-description">
+          {{#if materialshow.red}}
+            <div class='item flexrow red'>
+              <div class='item-name'><i class="fa-solid fa-paw"></i>{{localize "SW25.Item.Alchemytech.Red"}}</div>
+              <div class='quantity'>
+                {{#each materials.red.b as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.red.a as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.red.s as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.red.ss as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+          {{#if materialshow.green}}
+            <div class='item flexrow green'>
+              <div class='item-name'><i class="fa-solid fa-leaf"></i>{{localize "SW25.Item.Alchemytech.Green"}}</div>
+              <div class='quantity'>
+                {{#each materials.green.b as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.green.a as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.green.s as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.green.ss as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+          {{#if materialshow.black}}
+            <div class='item flexrow black'>
+              <div class='item-name'><i class="fa-solid fa-gem"></i>{{localize "SW25.Item.Alchemytech.Black"}}</div>
+              <div class='quantity'>
+                {{#each materials.black.b as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.black.a as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.black.s as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.black.ss as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+          {{#if materialshow.white}}
+            <div class='item flexrow white'>
+              <div class='item-name'><i class="fa-solid fa-heart"></i>{{localize "SW25.Item.Alchemytech.White"}}</div>
+              <div class='quantity'>
+                {{#each materials.white.b as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.white.a as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.white.s as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.white.ss as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+          {{#if materialshow.gold}}
+            <div class='item flexrow gold'>
+              <div class='item-name'><i class="fa-solid fa-sun"></i>{{localize "SW25.Item.Alchemytech.Gold"}}</div>
+              <div class='quantity'>
+                {{#each materials.gold.b as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.gold.a as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.gold.s as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+              <div class='quantity'>
+                {{#each materials.gold.ss as |item id|}}
+                  <li class='item' data-item-id='{{item._id}}'>
+                    <div>
+                      <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                        <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                          <i class="fas fa-minus"></i>
+                        </a>
+                        <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                        <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                          <i class="fas fa-plus"></i>
+                        </a>
+                        <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-edit'></i>
+                        </a>
+                        <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                          <i class='fas fa-trash'></i>
+                        </a>
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+        </div>
+      </div>
+      <div class='item-element' style="flex: 0 0 180px;">&nbsp;</div>
+    </div>
+  {{/if}}
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize "TYPES.Item.alchemytech"}}</div>
-    <div class='item-element' style="flex: 0 0 60px;">{{localize "SW25.Cost"}}</div>
+    <div class='item-name'>{{#if materialshow.all}}{{localize "SW25.Item.Name"}}{{else}}{{localize "TYPES.Item.alchemytech"}}{{/if}}</div>
+    <div class='item-element' style="flex: 0 0 120px;">{{localize "SW25.Cost"}}</div>
     <div class='item-element' style="flex: 0 0 120px;">{{localize "SW25.Rangeshape"}}</div>
     <div class='item-element' style="flex: 0 0 40px;">{{localize "SW25.Item.Resist"}}</div>
     <div class='item-controls'>
@@ -46,6 +550,12 @@
              {{#unless (eq system.black 0)}} {{localize "SW25.Item.Alchemytech.Black"}}{{system.black}}{{/unless}}
              {{#unless (eq system.white 0)}} {{localize "SW25.Item.Alchemytech.White"}}{{system.white}}{{/unless}}
              {{#unless (eq system.gold 0)}} {{localize "SW25.Item.Alchemytech.Gold"}}{{system.gold}}{{/unless}}
+        </div>
+        <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 60px;">
+          <div class="materialcardcost">B</div>
+          <div class="materialcardcost">A</div>
+          <div class="materialcardcost">S</div>
+          <div class="materialcardcost">SS</div>
         </div>
         <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 120px;">
           {{system.rangeshape}}

--- a/templates/actor/parts/actor-items.hbs
+++ b/templates/actor/parts/actor-items.hbs
@@ -39,17 +39,17 @@
           <b>{{localize "SW25.Item.EffectB"}}</b>
         </div>
         <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 60px;">
-{{!--
+
           <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
             <i class="fas fa-minus"></i>
           </a>
---}}
+
           <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
-{{!--
+
           <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
             <i class="fas fa-plus"></i>
           </a>
---}}
+
         </div>
         <div class='item-controls'>
           <a

--- a/templates/actor/parts/actor-magicalsongs.hbs
+++ b/templates/actor/parts/actor-magicalsongs.hbs
@@ -1,6 +1,43 @@
 <ol class='items-list'>
+  {{#if noteshow}}
+    <div class='item flexrow items-header'>
+      <div class='item-name'>{{localize "TYPES.Item.magicalsong"}}</div>
+    </div>
+    <div class='item flexrow ability-resource'>
+      <div class='item-name'>
+        <div class="abirity-label">{{localize "SW25.Item.Magicalsong.Music"}}</div>
+        {{#each notes as |item id|}}
+          <li class='item' data-item-id='{{item._id}}'>
+            <div>
+              <div class="item-prop flexrow flex-group-center">
+                <h4 class="item-label">{{item.name}}</h4>
+              </div>
+              <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                  <i class="fas fa-minus"></i>
+                </a>
+                <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                  <i class="fas fa-plus"></i>
+                </a>
+              </div>
+              <div class='item-controls'>
+                <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-edit'></i>
+                </a>
+                <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-trash'></i>
+                </a>
+              </div>
+            </div>
+          </li>
+        {{/each}}
+      </div>
+      <div class='item-element' style="flex: 0 0 240px;">&nbsp;</div>
+    </div>
+  {{/if}}
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize "TYPES.Item.magicalsong"}}</div>
+    <div class='item-name'>{{#if noteshow}}{{localize "SW25.Item.Name"}}{{else}}{{localize "TYPES.Item.magicalsong"}}{{/if}}</div>
     <div class='item-element' style="flex: 0 0 50px;">{{localize "SW25.Item.Magicalsong.Music"}}</div>
     <div class='item-element' style="flex: 0 0 70px;">{{localize "SW25.Adding"}}</div>
     <div class='item-element' style="flex: 0 0 40px;">{{localize "SW25.Item.Resist"}}</div>

--- a/templates/actor/parts/actor-phaseareas.hbs
+++ b/templates/actor/parts/actor-phaseareas.hbs
@@ -1,6 +1,44 @@
 <ol class='items-list'>
+  {{#if lifelineshow}}
+    <div class='item flexrow items-header'>
+      <div class='item-name'>{{localize "TYPES.Item.phasearea"}}</div>
+    </div>
+    <div class='item flexrow ability-resource'>
+      <div class='item-name'>
+        <div class="abirity-label">{{localize "SW25.Item.Phasearea.Lifeline"}}</div>
+        {{#each lifelines as |item id|}}
+          <li class='item' data-item-id='{{item._id}}'>
+            <div>
+              <div class="item-prop flexrow flex-group-center">
+                <h4 class="item-label">{{item.name}}</h4>
+              </div>
+              <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                  <i class="fas fa-minus"></i>
+                </a>
+                <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                 / {{item.system.qmax}}
+                <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                  <i class="fas fa-plus"></i>
+                </a>
+              </div>
+              <div class='item-controls'>
+                <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-edit'></i>
+                </a>
+                <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-trash'></i>
+                </a>
+              </div>
+            </div>
+          </li>
+        {{/each}}
+      </div>
+      <div class='item-element' style="flex: 0 0 240px;">&nbsp;</div>
+    </div>
+  {{/if}}
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize "TYPES.Item.phasearea"}}</div>
+    <div class='item-name'>{{#if lifelineshow}}{{localize "SW25.Item.Name"}}{{else}}{{localize "TYPES.Item.phasearea"}}{{/if}}</div>
     <div class='item-element' style="flex: 0 0 70px;">{{localize "SW25.Cost"}}</div>
     <div class='item-element' style="flex: 0 0 100px;">{{localize "SW25.Time"}}</div>
     <div class='item-element' style="flex: 0 0 80px;">{{localize "SW25.Item.Prop"}}</div>
@@ -30,6 +68,9 @@
             </a>
           </div>
           <{{system.typename}}{{localize "SW25.Item.Phasearea.Phase"}}><h4 class="item-label">{{item.name}}</h4>
+        </div>
+        <div class="usephasearea" style="flex: 0 0 40px; display: block;">
+          <b>{{localize "SW25.Use"}}</b>
         </div>
         <div class="rollable" style="flex: 0 0 40px; display: {{#if system.usedice}}block{{else}}none{{/if}};" data-roll="{{item.system.checkformula}}+{{item.system.checkbase}}" data-label="{{item.name}} ({{localize "SW25.Check"}})" data-pt="{{item.system.powertable}}" data-apply="{{system.applycheck}}" data-checktype="{{system.checkTypesButton}}">
           <b>{{localize "SW25.Item.CheckB"}}</b>

--- a/templates/actor/parts/actor-spells-abyssal.hbs
+++ b/templates/actor/parts/actor-spells-abyssal.hbs
@@ -1,4 +1,40 @@
 <ol class='items-list'>
+  {{#if abyssexshow}}
+    <div class='item flexrow items-header'>
+      <div class='item-name'>{{localize "SW25.Item.Resource.Types.AbyssEx"}}</div>
+    </div>
+    <div class='item flexrow ability-resource'>
+      <div class='item-name'>
+        {{#each abyssexs as |item id|}}
+          <li class='item' data-item-id='{{item._id}}'>
+            <div>
+              <div class="item-prop flexrow flex-group-center">
+                <h4 class="item-label">{{item.name}}</h4>
+              </div>
+              <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                  <i class="fas fa-minus"></i>
+                </a>
+                <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                  <i class="fas fa-plus"></i>
+                </a>
+              </div>
+              <div class='item-controls'>
+                <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-edit'></i>
+                </a>
+                <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-trash'></i>
+                </a>
+              </div>
+            </div>
+          </li>
+        {{/each}}
+      </div>
+      <div class='item-element' style="flex: 0 0 240px;">&nbsp;</div>
+    </div>
+  {{/if}}
   <li class='item flexrow items-header'>
     <div class='item-element' style="flex: 0 0 30px;">Lv</div>
     <div class='item-name'>{{localize "SW25.Item.Spell.Abyssal"}}</div>

--- a/templates/actor/parts/actor-tactics.hbs
+++ b/templates/actor/parts/actor-tactics.hbs
@@ -1,6 +1,43 @@
 <ol class='items-list'>
+  {{#if tacspowershow}}
+    <div class='item flexrow items-header'>
+      <div class='item-name'>{{localize "TYPES.Item.tactics"}}</div>
+    </div>
+    <div class='item flexrow ability-resource'>
+      <div class='item-name'>
+        <div class="abirity-label">{{localize "SW25.Item.Tactics.Tacspower"}}</div>
+        {{#each tacspowers as |item id|}}
+          <li class='item' data-item-id='{{item._id}}'>
+            <div>
+              <div class="item-prop flexrow flex-group-center">
+                <h4 class="item-label">{{item.name}}</h4>
+              </div>
+              <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                  <i class="fas fa-minus"></i>
+                </a>
+                <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                  <i class="fas fa-plus"></i>
+                </a>
+              </div>
+              <div class='item-controls'>
+                <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-edit'></i>
+                </a>
+                <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-trash'></i>
+                </a>
+              </div>
+            </div>
+          </li>
+        {{/each}}
+      </div>
+      <div class='item-element' style="flex: 0 0 240px;">&nbsp;</div>
+    </div>
+  {{/if}}
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize "TYPES.Item.tactics"}}</div>
+    <div class='item-name'>{{#if tacspowershow}}{{localize "SW25.Item.Name"}}{{else}}{{localize "TYPES.Item.tactics"}}{{/if}}</div>
     <div class='item-element' style="flex: 0 0 90px;">{{localize "SW25.Condition"}}</div>
     <div class='item-element' style="flex: 0 0 80px;">{{localize "SW25.Item.Tactics.Line"}}({{localize "SW25.Item.Tactics.Rank"}})</div>
     <div class='item-element' style="flex: 0 0 30px;">{{localize "SW25.Item.Tactics.Get"}}</div>

--- a/templates/effect/active-effect-config.hbs
+++ b/templates/effect/active-effect-config.hbs
@@ -145,6 +145,8 @@
                             <option value="attributes.efmppmod" {{#if (eq change.keyname "attributes.efmppmod")}}selected{{/if}}>{{localize "SW25.Effect.MppMod"}}</option>
                             <option value="attributes.efdreduce" {{#if (eq change.keyname "attributes.efdreduce")}}selected{{/if}}>{{localize "SW25.Effect.Dreduce"}}</option>
                             <option value="attributes.move.efmovemod" {{#if (eq change.keyname "attributes.move.efmovemod")}}selected{{/if}}>{{localize "SW25.Effect.MoveMod"}}</option>
+                            <option value="attributes.turnend.hpregenmod" {{#if (eq change.keyname "attributes.turnend.hpregenmod")}}selected{{/if}}>{{localize "SW25.Effect.HpregenMod"}}</option>
+                            <option value="attributes.turnend.mpregenmod" {{#if (eq change.keyname "attributes.turnend.mpregenmod")}}selected{{/if}}>{{localize "SW25.Effect.MpregenMod"}}</option>
                             {{/select}}
                             </select>
                         {{/if}}
@@ -159,10 +161,10 @@
                             <option value="effect.allck" {{#if (eq change.keyname "effect.allck")}}selected{{/if}}>{{localize "SW25.Config.AllCk"}}</option>
                             <option value="effect.allsk" {{#if (eq change.keyname "effect.allsk")}}selected{{/if}}>{{localize "SW25.Config.AllSk"}}</option>
                             <option value="eflootmod" {{#if (eq change.keyname "eflootmod")}}selected{{/if}}>{{localize "SW25.Monster.Loot"}}</option>
-                            <option value="effect.package.fine" {{#if (eq change.keyname "effect.package.fine")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Finesse"}}{{localize "SW25.Check"}}</option>
-                            <option value="effect.package.move" {{#if (eq change.keyname "effect.package.move")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Movement"}}{{localize "SW25.Check"}}</option>
-                            <option value="effect.package.obse" {{#if (eq change.keyname "effect.package.obse")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Observation"}}{{localize "SW25.Check"}}</option>
-                            <option value="effect.package.know" {{#if (eq change.keyname "effect.package.know")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Knowledge"}}{{localize "SW25.Check"}}</option>
+                            <option value="effect.package.fine" {{#if (eq change.keyname "effect.package.fine")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Finesse"}}</option>
+                            <option value="effect.package.move" {{#if (eq change.keyname "effect.package.move")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Movement"}}</option>
+                            <option value="effect.package.obse" {{#if (eq change.keyname "effect.package.obse")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Observation"}}</option>
+                            <option value="effect.package.know" {{#if (eq change.keyname "effect.package.know")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Knowledge"}}</option>
                             {{/select}}
                             </select>
                         {{/if}}

--- a/templates/effect/active-effect-config.hbs
+++ b/templates/effect/active-effect-config.hbs
@@ -159,6 +159,10 @@
                             <option value="effect.allck" {{#if (eq change.keyname "effect.allck")}}selected{{/if}}>{{localize "SW25.Config.AllCk"}}</option>
                             <option value="effect.allsk" {{#if (eq change.keyname "effect.allsk")}}selected{{/if}}>{{localize "SW25.Config.AllSk"}}</option>
                             <option value="eflootmod" {{#if (eq change.keyname "eflootmod")}}selected{{/if}}>{{localize "SW25.Monster.Loot"}}</option>
+                            <option value="effect.package.fine" {{#if (eq change.keyname "effect.package.fine")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Finesse"}}{{localize "SW25.Check"}}</option>
+                            <option value="effect.package.move" {{#if (eq change.keyname "effect.package.move")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Movement"}}{{localize "SW25.Check"}}</option>
+                            <option value="effect.package.obse" {{#if (eq change.keyname "effect.package.obse")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Observation"}}{{localize "SW25.Check"}}</option>
+                            <option value="effect.package.know" {{#if (eq change.keyname "effect.package.know")}}selected{{/if}}>{{localize "SW25.Item.Check.Packages.Knowledge"}}{{localize "SW25.Check"}}</option>
                             {{/select}}
                             </select>
                         {{/if}}

--- a/templates/item/item-check-sheet.hbs
+++ b/templates/item/item-check-sheet.hbs
@@ -95,6 +95,17 @@
             {{/if}}
           </span>
           {{/unless}}
+          <span class="grid-span-2" style="text-align: center;"><b>{{localize "SW25.Item.Check.Package"}}</b><br>
+            <select name="system.checkpackage">
+              {{#select system.checkpackage}}
+              <option value="-">-</option>
+              <option value="fine">{{localize "SW25.Item.Check.Packages.Finesse"}}</option>
+              <option value="move">{{localize "SW25.Item.Check.Packages.Movement"}}</option>
+              <option value="obse">{{localize "SW25.Item.Check.Packages.Observation"}}</option>
+              <option value="know">{{localize "SW25.Item.Check.Packages.Knowledge"}}</option>
+              {{/select}}
+            </select>
+          </span>
         </div>
         <div style="display: {{#if (eq system.checkmethod "power")}}block{{else}}none{{/if}};">
           <div class="flexrow grid grid-8col">

--- a/templates/item/item-resource-sheet.hbs
+++ b/templates/item/item-resource-sheet.hbs
@@ -34,8 +34,8 @@
   {{!-- Sheet Tab Navigation --}}
   <nav class="sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="description">{{localize "SW25.Description"}}</a>
-    {{!--
     <a class="item" data-tab="details">{{localize "SW25.Details"}}</a>
+    {{!--
     <a class="item" data-tab="effects">{{localize "SW25.Effects"}}</a>
     --}}
   </nav>
@@ -52,27 +52,73 @@
     <div class="tab details" data-group="primary" data-tab="details">
       <div class="flexcol">
         <div class="flexrow grid grid-10col nogapmargin">
-          <span class="grid-span-3" style="text-align: center;"><b>{{localize "SW25.Item.Clickitem"}}</b><br>
-            <select name="system.clickitem">
-              {{#select system.clickitem}}
-              <option value="all">{{localize "SW25.Item.All"}}</option>
-              <option value="power">{{localize "SW25.Item.Powerroll"}}</option>
-              <option value="dice">{{localize "SW25.Item.Diceroll"}}</option>
-              <option value="description">{{localize "SW25.Item.Onlydescription"}}</option>
+          <span class="grid-span-2"  style="text-align: center;"><b>{{localize "SW25.Item.Resource.Battle"}}</b></label><br>
+            <input id="{{item._id}}system.resource.isNotBattle" type="checkbox" name="system.resource.isNotBattle" data-dtype="Boolean" {{#if system.resource.isNotBattle}} checked {{/if}}/></span>
+          <span class="grid-span-3" style="text-align: center;">
+            <b>{{localize "SW25.Item.Resource.Type"}}</b><br>
+            <select name="system.resource.type">
+              {{#select system.resource.type}}
+              <option value="none">{{localize "SW25.Item.Resource.Types.None"}}</option>
+              <option value="note">{{localize "SW25.Item.Resource.Types.Note"}}</option>
+              <option value="material">{{localize "SW25.Item.Resource.Types.Material"}}</option>
+              <option value="lifeline">{{localize "SW25.Item.Resource.Types.Lifeline"}}</option>
+              <option value="tacspower">{{localize "SW25.Item.Resource.Types.Tacspower"}}</option>
+              <option value="abyssex">{{localize "SW25.Item.Resource.Types.AbyssEx"}}</option>
               {{/select}}
             </select>
           </span>
-          <div class="grid-span-3"></div>
-          <span class="grid-span-2"  style="text-align: center;"><label for="{{item._id}}system.usedice"><b>{{localize "SW25.Item.Usedice"}}</b></label><br>
-            <input id="{{item._id}}system.usedice" type="checkbox" name="system.usedice" data-dtype="Boolean" {{#if system.usedice}} checked {{/if}}/></span>
-          <span class="grid-span-2"  style="text-align: center;"><label for="{{item._id}}system.usepower"><b>{{localize "SW25.Item.Usepower"}}</b></label><br>
-            <input id="{{item._id}}system.usepower" type="checkbox" name="system.usepower" data-dtype="Boolean" {{#if system.usepower}} checked {{/if}}/></span>
-        </div>
-        <div style="display: {{#if system.usedice}}block{{else}}none{{/if}};">
-          {{> "systems/sw25/templates/item/parts/item-usedice.hbs"}}
-        </div>
-        <div style="display: {{#if system.usepower}}block{{else}}none{{/if}};">
-          {{> "systems/sw25/templates/item/parts/item-usepower.hbs"}}
+          <div class="grid-span-3" style="display: {{#if system.resource.isNote}}block{{else}}none{{/if}}; text-align: center;">
+            <b>{{localize "SW25.Item.Resource.Types.Note"}}</b><br>
+            <select name="system.resource.notetype">
+              {{#select system.resource.notetype}}
+              <option value="up">{{localize "SW25.Item.Magicalsong.Up"}}</option>
+              <option value="down">{{localize "SW25.Item.Magicalsong.Down"}}</option>
+              <option value="charm">{{localize "SW25.Item.Magicalsong.Charm"}}</option>
+              {{/select}}
+            </select>
+          </div>
+          <div class="grid-span-3" style="display: {{#if system.resource.isMaterial}}block{{else}}none{{/if}}; text-align: center;">
+            <b>{{localize "SW25.Item.Resource.Types.Material"}}</b><br>
+            <select name="system.resource.materialtype">
+              {{#select system.resource.materialtype}}
+              <option value="red">{{localize "SW25.Item.Alchemytech.Red"}}</option>
+              <option value="green">{{localize "SW25.Item.Alchemytech.Green"}}</option>
+              <option value="black">{{localize "SW25.Item.Alchemytech.Black"}}</option>
+              <option value="white">{{localize "SW25.Item.Alchemytech.White"}}</option>
+              <option value="gold">{{localize "SW25.Item.Alchemytech.Gold"}}</option>
+              {{/select}}
+            </select>
+            <select name="system.resource.materialrank">
+              {{#select system.resource.materialrank}}
+              <option value="b">{{localize "SW25.Item.Alchemytech.B"}}</option>
+              <option value="a">{{localize "SW25.Item.Alchemytech.A"}}</option>
+              <option value="s">{{localize "SW25.Item.Alchemytech.S"}}</option>
+              <option value="ss">{{localize "SW25.Item.Alchemytech.SS"}}</option>
+              {{/select}}
+            </select>
+          </div>
+          <div class="grid-span-3" style="display: {{#if system.resource.isLifeline}}block{{else}}none{{/if}}; text-align: center;">
+            <b>{{localize "SW25.Item.Resource.Types.Lifeline"}}</b><br>
+            <select name="system.resource.lifelinetype">
+              {{#select system.resource.lifelinetype}}
+              <option value="ten">{{localize "SW25.Item.Phasearea.Ten"}}</option>
+              <option value="chi">{{localize "SW25.Item.Phasearea.Chi"}}</option>
+              <option value="jin">{{localize "SW25.Item.Phasearea.Jin"}}</option>
+              {{/select}}
+            </select>
+          </div>
+          <div class="grid-span-3" style="display: {{#if system.resource.isAbyssEx}}block{{else}}none{{/if}}; text-align: center;">
+            <b>{{localize "SW25.Item.Resource.Types.AbyssEx"}}</b><br>
+            <select name="system.resource.abyssextype">
+              {{#select system.resource.abyssextype}}
+              <option value="deamonblood">{{localize "SW25.Item.Resource.Deamonblood"}}</option>
+              <option value="deamoncrystal">{{localize "SW25.Item.Resource.Deamoncrystal"}}</option>
+              <option value="deamoncrystalL">{{localize "SW25.Item.Resource.DeamoncrystalLarge"}}</option>
+              <option value="abyssshard">{{localize "SW25.Item.Resource.Abyssshard"}}</option>
+              {{/select}}
+            </select>
+          </div>
+          <div class="grid-span-2"></div>
         </div>
       </div>
     </div>

--- a/templates/roll/card-apply.hbs
+++ b/templates/roll/card-apply.hbs
@@ -1,0 +1,4 @@
+{{#if flavor}}<span class="flavor-text">{{flavor}}</span>{{/if}}
+<div style="text-align: left;">
+    {{{message}}}
+</div>

--- a/templates/roll/hpmp-apply.hbs
+++ b/templates/roll/hpmp-apply.hbs
@@ -1,0 +1,23 @@
+{{#if flavor}}<span class="flavor-text">{{flavor}}</span>{{/if}}
+<div class="flexrow flex-group-center grid grid-3col nogapmargin">
+    {{#if hpregen}}
+    <div class="grid-span-3" style="text-align: center;">
+        HP
+        {{#if isView}}
+        <span style="color: #862020; font-weight: bold; font-size: 1.5em;"> {{targetHP}}</span>
+        >>><span style="color: #862020; font-weight: bold; font-size: 1.5em;"> {{resultHP}}</span>
+        {{/if}}
+        (<span style="color: #202086; font-weight: bold; font-size: 1.5em;">{{hpregen}}</span>)
+    </div>
+    {{/if}}
+    {{#if mpregen}}
+    <div class="grid-span-3" style="text-align: center;">
+        MP
+        {{#if isView}}
+        <span style="color: #862020; font-weight: bold; font-size: 1.5em;"> {{targetMP}}</span>
+        >>><span style="color: #862020; font-weight: bold; font-size: 1.5em;"> {{resultMP}}</span>
+        {{/if}}
+        (<span style="color: #202086; font-weight: bold; font-size: 1.5em;">{{mpregen}}</span>)
+    </div>
+    {{/if}}
+</div>

--- a/templates/roll/rollreq-card.hbs
+++ b/templates/roll/rollreq-card.hbs
@@ -1,0 +1,4 @@
+<strong>{{message}}</strong><br>
+{{difficulty}}{{#if targetValue}}:{{targetValue}}{{/if}}<br>
+<hr>
+<div><button class="buttonclick" data-buttontype="buttonrollreq">{{checkName}} {{localize "SW25.Check"}} {{#if mod}}({{mod}}){{/if}}</button></div>


### PR DESCRIPTION
- キャラクターシート上、タブが上部に残り続けるように変更
![image](https://github.com/user-attachments/assets/760d56b3-13f1-416c-810c-ef00347f387f)
![image](https://github.com/user-attachments/assets/be1a633c-5295-4afd-904e-9bddaaa330af)

- 武器の専用化時、器用度を+2した状態で命中力を判定するように変更
- increase/decreaseにおいて、値が入っていない場合にも増減できるように修正

- 魔物データから魔物知識判定／先制判定のロール要求ができるように追加
![image](https://github.com/user-attachments/assets/7ce69523-ec6f-4055-8168-eebd0e5a51ec)
知名度/弱点値、先制値のところをクリックすることでロール要求
あわせて、ロール要求回りをtemplateから取得するように修正、知名度/弱点値のように２段階の判定時に成功数を記録するように修正

- 妖精魔法の契約状況管理を追加
契約状況により、使用可能ランクを表示する
![image](https://github.com/user-attachments/assets/6f4aaac5-81b4-4cde-b149-ccb220a95e91)
![image](https://github.com/user-attachments/assets/af1c689c-c81b-45db-ae55-0fbae339fbd1)

- リソース詳細設定の追加
リソースに詳細タブを表示し、項目を追加
「戦闘タブ非表示」…リソース種別「なし」以外の場合、戦闘タブ上からリソースを非表示することができる
「リソース種別」…各技能で使用するリソースを設定可能
![image](https://github.com/user-attachments/assets/ecdeb16a-7754-4f23-b326-6952f179840f)

- 「楽素」リソース
楽素リソースが設定されている場合、呪歌・終律の上部にリソースを表示
![image](https://github.com/user-attachments/assets/91aa1a71-c6e6-4b96-a74c-492a9ae2f59d)

- 「マテリアルカード」リソース
マテリアルカードリソースが設定されている場合、賦術の上部にリソースを表示
![image](https://github.com/user-attachments/assets/c6a1cbfa-302e-4c5f-8543-1899679a9de7)
該当の色のリソースが１つも設定されていない場合は行を非表示
![image](https://github.com/user-attachments/assets/6c96534a-6a9c-492f-844f-4085008ac6c7)
賦術の消費から該当ランクを選択すると、自動的にリソースから消費する
![image](https://github.com/user-attachments/assets/4f985e66-1c48-43f2-8d59-a7c395b86643)
該当するリソースが設定されていない場合はその旨を表示
![image](https://github.com/user-attachments/assets/5dfcad12-b9dd-4cda-a03b-d94ecb1b52aa)

- 「命脈点」リソース
命脈点のリソースが設定されている場合、相域の上部にリソースを表示
![image](https://github.com/user-attachments/assets/cf823e6b-7b6e-49f3-b0be-dc4f313434b0)
相域「使用」を実行すると、命脈点の消費ダイアログを表示（固定消費の場合はダイアログは表示されない）
![image](https://github.com/user-attachments/assets/be4d01f2-abe8-4165-bd14-02a9dc6dea41)
相域を使用すると、バフ欄にて使用中の相域・使用命脈点が追加される
![image](https://github.com/user-attachments/assets/e28a6e4b-8de8-40dd-a409-fb403e753036)
![image](https://github.com/user-attachments/assets/d05378bc-9f35-42dd-b33d-b09958bc77b0)

- 「陣気」リソース
陣気のリソースが設定されている場合、鼓咆・陣率の上部にリソースを表示 
![image](https://github.com/user-attachments/assets/0bfca304-6c74-47bf-be16-35e61a7f5ba5)

- 「奈落魔法」リソース
奈落魔法拡張素材のリソースが設定されている場合、奈落魔法の上部にリソースを表示
![image](https://github.com/user-attachments/assets/6158fa71-add9-4c2f-8101-8bfc317ee0a9)

- 判定／バフ機能
判定アイテムに「判定パッケージ」項目を追加
ActiveEffectアイテムに判定パッケージ強化用の項目を追加
![image](https://github.com/user-attachments/assets/7f26f1ab-f8f1-4571-a6b5-a17ca5a94087)
![image](https://github.com/user-attachments/assets/6cd370d6-dd87-4293-9c92-f61a883a0751)
