### PR TITLE
セッション管理用アイテムの追加など

### DIFF
--- a/css/sw25.css
+++ b/css/sw25.css
@@ -83,6 +83,11 @@
   cursor: pointer;
 }
 
+.session-result:hover, .session-result:focus {
+  color: #000;
+  text-shadow: 0 0 10px red;
+  cursor: pointer;
+}
 
 .grid,
 .grid-2col {
@@ -1452,4 +1457,59 @@ input.weakapply[type="checkbox"] {
 
 .fairy-rank {
   font-size: 0.7em;
+}
+
+.session-result-title {
+  font-size: 0.8em;
+  text-align: center;
+}
+
+.session-result-chat .title{
+  background: linear-gradient(210deg, rgb(160, 205, 255), rgb(255, 165, 180));
+  border: 1px solid #333;
+  padding: 8px 12px;
+  border-radius: 5px;
+  font-weight:bold;
+}
+
+.session-result-chat .basic-info,
+.session-result-chat .session-info{
+  border: 1px solid #333;
+  padding: 2px;
+  margin: 2px;
+}
+
+.session-result-chat .basic-info .contents,
+.session-result-chat .session-info .contents{
+  padding-left:1em;
+	text-indent:-1em;
+}
+
+.session-result-chat .custom-info table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.session-result-chat .custom-info .header-title,
+.session-result-chat .custom-info .contents-title,
+.session-result-chat .custom-info .header-value,
+.session-result-chat .custom-info .contents-value{
+  min-width: 10%;
+}
+
+.sw25 .customs .item .custom-value,
+.sw25 .customs .item .custom-controls {
+  text-align: center;
+  border-left: 1px solid #c9c7b8;
+  border-right: 1px solid #c9c7b8;
+  font-size: 12px;
+}
+
+.sw25 .customs .item .effect-controls {
+  border: none;
+}
+
+.sw25 .details .session-detail {
+  gap: 0px;
+  margin: 0px;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,6 +21,7 @@
     "Spells": "Spells",
     "Effects": "Effects",
     "Effectslong": "Effects",
+    "Customs": "Customs",
     "Description": "Description",
     "Details": "Details",
     "Abilityname": "Ability",
@@ -458,8 +459,13 @@
           "Material": "Material Card",
           "Lifeline": "Qi",
           "Tacspower": "Edge",
+          "Magitech": "Magitech",
           "AbyssEx": "Abyss Extend"
         },
+        "Bullet": "Bullet",
+        "MagisphereS": "Magi Sphere S",
+        "MagisphereM": "Magi Sphere M",
+        "MagisphereL": "Magi Sphere L",
         "Deamonblood": "Deamon Blood",
         "Deamoncrystal": "Deamon Crystal",
         "DeamoncrystalLarge": "Arcdeamon Crystal",
@@ -520,7 +526,35 @@
         "ActionEffect": "Effect",
         "TableType": "Action Table Type",
         "Label": "Label"
-      }
+      },
+      "Session": {
+        "Information": "Information",
+        "Date": "Date",
+        "GM": "GameMaster",
+        "PC": "PC Num",
+        "Player": "Player",
+        "Exp": "Experience",
+        "Gamel": "Gamel",
+        "Honor": "Honor",
+        "Sword": "Sword Shard",
+        "Abyss": "Abyss Shard",
+        "Tresure": "Tresure Point",
+        "Mission": "Mission",
+        "Middle": "Middle",
+        "OutputResult": "Output Result",
+        "BasicResult": "Basic Info",
+        "SwordResult": "Sword Calc",
+        "CharaResult": "Fumble Calc",
+        "CustomResult" : "Custom Info",
+        "Result": {
+          "Label": "Session Result",
+          "Remainder": "Remainder",
+          "Character": "Character",
+          "Fumble": "Fumble",
+          "Item": "Item",
+          "Value": "Value"
+       }
+     }
     },
     "Effect": {
       "Source": "Source",
@@ -580,6 +614,13 @@
       "DmMod": "Summoning",
       "AbMod": "Abyssal Magic"
     },
+    "Custom": {
+      "Name": "Name",
+      "Value": "Value",
+      "MoveUp": "Move Up",
+      "MoveDown": "Move Down",
+      "Delete": "Delete"
+    },
     "Config": {
       "ResVit": "Fortitude",
       "ResMnd": "Willpower",
@@ -627,7 +668,8 @@
       "language": "Language",
       "otherfeature": "Other Features",
       "monsterability": "Monster Ability",
-      "action": "Action"
+      "action": "Action",
+      "session": "Session"
     }
   },
 

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -21,6 +21,7 @@
     "Spells": "魔法",
     "Effects": "バフ",
     "Effectslong": "バフ・デバフ",
+    "Customs": "カスタム項目",
     "Description": "説明",
     "Details": "詳細",
     "Abilityname": "能力値",
@@ -168,7 +169,7 @@
       "Corepart": "コア部位",
       "Ability": "魔物能力",
       "Loot": "戦利品",
-      "Usespell": "魔法使用",
+      "Usespell": "魔法・特技使用",
       "Unidentifiedmon": "不明の魔物"
     },
     "SheetLabels": {
@@ -459,8 +460,13 @@
           "Material": "マテリアルカード",
           "Lifeline": "命脈点",
           "Tacspower": "陣気",
+          "Magitech": "魔動機術",
           "AbyssEx": "奈落魔法拡張素材"
         },
+        "Bullet": "弾丸",
+        "MagisphereS": "マギスフィア小",
+        "MagisphereM": "マギスフィア中",
+        "MagisphereL": "マギスフィア大",
         "Deamonblood": "悪魔の血",
         "Deamoncrystal": "悪魔の血晶",
         "DeamoncrystalLarge": "大悪魔の血晶",
@@ -520,6 +526,34 @@
         "ActionEffect": "効果",
         "TableType": "行動表タイプ",
         "Label": "ラベル"
+      },
+      "Session": {
+        "Information": "セッション情報",
+        "Date": "日付",
+        "GM": "GM名",
+        "PC": "PC数",
+        "Player": "参加者",
+        "Exp": "経験点",
+        "Gamel": "ガメル",
+        "Honor": "名誉点",
+        "Sword": "剣のかけら",
+        "Abyss": "アビスシャード",
+        "Tresure": "トレジャーポイント",
+        "Mission": "依頼達成分",
+        "Middle": "戦利品",
+        "OutputResult": "セッション結果出力",
+        "BasicResult": "基本情報",
+        "SwordResult": "剣のかけら納品",
+        "CharaResult": "1ゾロ回数",
+        "CustomResult" : "カスタム項目",
+        "Result": {
+          "Label": "セッション結果",
+          "Remainder": "余",
+          "Character": "キャラクター",
+          "Fumble": "1ゾロ",
+          "Item": "項目名",
+          "Value": "値"
+       }
       }
     },
     "Effect": {
@@ -580,6 +614,13 @@
       "DmMod": "召異魔法",
       "AbMod": "奈落魔法"
     },
+    "Custom": {
+      "Name": "項目名",
+      "Value": "値",
+      "MoveUp": "上に移動",
+      "MoveDown": "下に移動",
+      "Delete": "削除"
+    },
     "Config": {
       "ResVit": "生命抵抗力",
       "ResMnd": "精神抵抗力",
@@ -627,7 +668,8 @@
       "language": "言語",
       "otherfeature": "その他の特技",
       "monsterability": "魔物能力",
-      "action": "行動"
+      "action": "行動",
+      "session": "セッション"
     }
   },
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1013,11 +1013,13 @@ export class SW25Actor extends Actor {
     systemData.hp.max =
       Number(systemData.hpbase) +
       Number(systemData.hp.hpmod) +
-      Number(systemData.hp.efhpmod);
+      Number(systemData.hp.efhpmod) +
+      Math.floor((systemData.abilities?.vit?.efvaluemodify ?? 0) / 6);
     systemData.mp.max =
       Number(systemData.mpbase) +
       Number(systemData.mp.mpmod) +
-      Number(systemData.mp.efmpmod);
+      Number(systemData.mp.efmpmod) +
+      Math.floor((systemData.abilities?.mnd?.efvaluemodify ?? 0) / 6);
     systemData.pp =
       Number(systemData.ppbase) +
       Number(systemData.attributes.ppmod) +
@@ -1263,6 +1265,18 @@ export class SW25Actor extends Actor {
       }
     });
 
+    // Convert Status Monster Parameter.
+    totalhitmod += Math.floor((totaldex ?? 0) / 6) + (totaldexmod ?? 0);
+    totaldmod += Math.floor((totalstr ?? 0) / 6) + (totalstrmod ?? 0);
+    totaldodgemod += Math.floor((totalagi ?? 0) / 6) + (totalagimod ?? 0);
+    totalvitres += Math.floor((totalvit ?? 0) / 6) + (totalvitmod ?? 0);
+    totalmndres += Math.floor((totalmnd ?? 0) / 6) + (totalmndmod ?? 0);
+    totalmovemod += (totalagi ?? 0);
+    totalinit += Math.floor((totalagi ?? 0) / 6) + (totalagimod ?? 0);
+    totalhpmod += (totalvit ?? 0);
+    totalmpmod += (totalmnd ?? 0);
+    totalallmgp += Math.floor((totalint ?? 0) / 6) + (totalintmod ?? 0);
+    
     systemData.totalhitmod = totalhitmod;
     systemData.totaldmod = totaldmod;
     systemData.totalcmod = totalcmod;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -75,6 +75,8 @@ export class SW25Item extends Item {
         data.img = "icons/svg/skull.svg";
       } else if (data.type === "action") {
         data.img = "icons/svg/ice-aura.svg";
+      } else if (data.type === "session") {
+        data.img = "icons/svg/book.svg";
       }
     }
     // Default behavior, just call super() and do all the default Item inits
@@ -118,6 +120,7 @@ export class SW25Item extends Item {
     this._prepareSpellData(itemData);
     this._prepareMonsterabilityData(itemData);
     this._prepareActionData(itemData);
+    this._prepareSessionData(itemData);
   }
 
   async _prepareSkillData(itemData, actor) {
@@ -516,7 +519,8 @@ export class SW25Item extends Item {
       itemData.type !== "combatability" &&
       itemData.type !== "raceability" &&
       itemData.type !== "monsterability" &&
-      itemData.type !== "action"
+      itemData.type !== "action" &&
+      itemData.type !== "session"
     )
       return;
 
@@ -638,312 +642,312 @@ export class SW25Item extends Item {
     let powerabimod = 0;
     let dedicatedDex =
       itemData.type === "weapon" && itemData.system.dedicated ? 2 : 0;
-    if (actor.type == "character") {
-      if (systemData.checkabi == "dex")
-        checkabimod = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.dex.valuebase +
-            actorData.abilities.dex.valuegrowth +
-            actorData.abilities.dex.valuemodify +
-            actorData.abilities.dex.efvaluemodify +
-            dedicatedDex) /
-            6 +
-            Number(actorData.abilities.dex.efmodify)
-        );
-      if (systemData.checkabi == "agi")
-        checkabimod = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.agi.valuebase +
-            actorData.abilities.agi.valuegrowth +
-            actorData.abilities.agi.valuemodify +
-            actorData.abilities.agi.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.agi.efmodify)
-        );
-      if (systemData.checkabi == "str")
-        checkabimod = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.str.valuebase +
-            actorData.abilities.str.valuegrowth +
-            actorData.abilities.str.valuemodify +
-            actorData.abilities.str.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.str.efmodify)
-        );
-      if (systemData.checkabi == "vit")
-        checkabimod = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.vit.valuebase +
-            actorData.abilities.vit.valuegrowth +
-            actorData.abilities.vit.valuemodify +
-            actorData.abilities.vit.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.vit.efmodify)
-        );
-      if (systemData.checkabi == "int")
-        checkabimod = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.int.valuebase +
-            actorData.abilities.int.valuegrowth +
-            actorData.abilities.int.valuemodify +
-            actorData.abilities.int.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.int.efmodify)
-        );
-      if (systemData.checkabi == "mnd")
-        checkabimod = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.mnd.valuebase +
-            actorData.abilities.mnd.valuegrowth +
-            actorData.abilities.mnd.valuemodify +
-            actorData.abilities.mnd.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.mnd.efmodify)
-        );
-      if (systemData.powerabi == "dex")
-        powerabimod = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.dex.valuebase +
-            actorData.abilities.dex.valuegrowth +
-            actorData.abilities.dex.valuemodify +
-            actorData.abilities.dex.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.dex.efmodify)
-        );
-      if (systemData.powerabi == "agi")
-        powerabimod = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.agi.valuebase +
-            actorData.abilities.agi.valuegrowth +
-            actorData.abilities.agi.valuemodify +
-            actorData.abilities.agi.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.agi.efmodify)
-        );
-      if (systemData.powerabi == "str")
-        powerabimod = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.str.valuebase +
-            actorData.abilities.str.valuegrowth +
-            actorData.abilities.str.valuemodify +
-            actorData.abilities.str.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.str.efmodify)
-        );
-      if (systemData.powerabi == "vit")
-        powerabimod = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.vit.valuebase +
-            actorData.abilities.vit.valuegrowth +
-            actorData.abilities.vit.valuemodify +
-            actorData.abilities.vit.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.vit.efmodify)
-        );
-      if (systemData.powerabi == "int")
-        powerabimod = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.int.valuebase +
-            actorData.abilities.int.valuegrowth +
-            actorData.abilities.int.valuemodify +
-            actorData.abilities.int.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.int.efmodify)
-        );
-      if (systemData.powerabi == "mnd")
-        powerabimod = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.mnd.valuebase +
-            actorData.abilities.mnd.valuegrowth +
-            actorData.abilities.mnd.valuemodify +
-            actorData.abilities.mnd.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.mnd.efmodify)
-        );
-    }
-    if (actor.type == "character" || actor.type == "npc") {
-      if (systemData.checkabi1 == "dex")
-        checkabimod1 = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.dex.valuebase +
-            actorData.abilities.dex.valuegrowth +
-            actorData.abilities.dex.valuemodify +
-            actorData.abilities.dex.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.dex.efmodify)
-        );
-      if (systemData.checkabi1 == "agi")
-        checkabimod1 = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.agi.valuebase +
-            actorData.abilities.agi.valuegrowth +
-            actorData.abilities.agi.valuemodify +
-            actorData.abilities.agi.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.agi.efmodify)
-        );
-      if (systemData.checkabi1 == "str")
-        checkabimod1 = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.str.valuebase +
-            actorData.abilities.str.valuegrowth +
-            actorData.abilities.str.valuemodify +
-            actorData.abilities.str.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.str.efmodify)
-        );
-      if (systemData.checkabi1 == "vit")
-        checkabimod1 = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.vit.valuebase +
-            actorData.abilities.vit.valuegrowth +
-            actorData.abilities.vit.valuemodify +
-            actorData.abilities.vit.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.vit.efmodify)
-        );
-      if (systemData.checkabi1 == "int")
-        checkabimod1 = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.int.valuebase +
-            actorData.abilities.int.valuegrowth +
-            actorData.abilities.int.valuemodify +
-            actorData.abilities.int.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.int.efmodify)
-        );
-      if (systemData.checkabi1 == "mnd")
-        checkabimod1 = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.mnd.valuebase +
-            actorData.abilities.mnd.valuegrowth +
-            actorData.abilities.mnd.valuemodify +
-            actorData.abilities.mnd.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.mnd.efmodify)
-        );
-      if (systemData.checkabi2 == "dex")
-        checkabimod2 = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.dex.valuebase +
-            actorData.abilities.dex.valuegrowth +
-            actorData.abilities.dex.valuemodify +
-            actorData.abilities.dex.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.dex.efmodify)
-        );
-      if (systemData.checkabi2 == "agi")
-        checkabimod2 = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.agi.valuebase +
-            actorData.abilities.agi.valuegrowth +
-            actorData.abilities.agi.valuemodify +
-            actorData.abilities.agi.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.agi.efmodify)
-        );
-      if (systemData.checkabi2 == "str")
-        checkabimod2 = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.str.valuebase +
-            actorData.abilities.str.valuegrowth +
-            actorData.abilities.str.valuemodify +
-            actorData.abilities.str.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.str.efmodify)
-        );
-      if (systemData.checkabi2 == "vit")
-        checkabimod2 = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.vit.valuebase +
-            actorData.abilities.vit.valuegrowth +
-            actorData.abilities.vit.valuemodify +
-            actorData.abilities.vit.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.vit.efmodify)
-        );
-      if (systemData.checkabi2 == "int")
-        checkabimod2 = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.int.valuebase +
-            actorData.abilities.int.valuegrowth +
-            actorData.abilities.int.valuemodify +
-            actorData.abilities.int.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.int.efmodify)
-        );
-      if (systemData.checkabi2 == "mnd")
-        checkabimod2 = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.mnd.valuebase +
-            actorData.abilities.mnd.valuegrowth +
-            actorData.abilities.mnd.valuemodify +
-            actorData.abilities.mnd.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.mnd.efmodify)
-        );
-      if (systemData.checkabi3 == "dex")
-        checkabimod3 = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.dex.valuebase +
-            actorData.abilities.dex.valuegrowth +
-            actorData.abilities.dex.valuemodify +
-            actorData.abilities.dex.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.dex.efmodify)
-        );
-      if (systemData.checkabi3 == "agi")
-        checkabimod3 = Math.floor(
-          (actorData.abilities.dex.racevalue +
-            actorData.abilities.agi.valuebase +
-            actorData.abilities.agi.valuegrowth +
-            actorData.abilities.agi.valuemodify +
-            actorData.abilities.agi.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.agi.efmodify)
-        );
-      if (systemData.checkabi3 == "str")
-        checkabimod3 = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.str.valuebase +
-            actorData.abilities.str.valuegrowth +
-            actorData.abilities.str.valuemodify +
-            actorData.abilities.str.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.str.efmodify)
-        );
-      if (systemData.checkabi3 == "vit")
-        checkabimod3 = Math.floor(
-          (actorData.abilities.str.racevalue +
-            actorData.abilities.vit.valuebase +
-            actorData.abilities.vit.valuegrowth +
-            actorData.abilities.vit.valuemodify +
-            actorData.abilities.vit.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.vit.efmodify)
-        );
-      if (systemData.checkabi3 == "int")
-        checkabimod3 = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.int.valuebase +
-            actorData.abilities.int.valuegrowth +
-            actorData.abilities.int.valuemodify +
-            actorData.abilities.int.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.int.efmodify)
-        );
-      if (systemData.checkabi3 == "mnd")
-        checkabimod3 = Math.floor(
-          (actorData.abilities.int.racevalue +
-            actorData.abilities.mnd.valuebase +
-            actorData.abilities.mnd.valuegrowth +
-            actorData.abilities.mnd.valuemodify +
-            actorData.abilities.mnd.efvaluemodify) /
-            6 +
-            Number(actorData.abilities.mnd.efmodify)
-        );
-    }
-
+      if (actor.type == "character" || actor.type == "monster") {
+        if (systemData.checkabi == "dex")
+          checkabimod = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.dex?.valuebase ?? 0) +
+              (actorData.abilities?.dex?.valuegrowth ?? 0) +
+              (actorData.abilities?.dex?.valuemodify ?? 0) +
+              (actorData.abilities?.dex?.efvaluemodify ?? 0) +
+              dedicatedDex) /
+              6 +
+              Number((actorData.abilities?.dex?.efmodify ?? 0))
+          );
+        if (systemData.checkabi == "agi")
+          checkabimod = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.agi?.valuebase ?? 0) +
+              (actorData.abilities?.agi?.valuegrowth ?? 0) +
+              (actorData.abilities?.agi?.valuemodify ?? 0) +
+              (actorData.abilities?.agi?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.agi?.efmodify ?? 0))
+          );
+        if (systemData.checkabi == "str")
+          checkabimod = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.str?.valuebase ?? 0) +
+              (actorData.abilities?.str?.valuegrowth ?? 0) +
+              (actorData.abilities?.str?.valuemodify ?? 0) +
+              (actorData.abilities?.str?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.str?.efmodify ?? 0))
+          );
+        if (systemData.checkabi == "vit")
+          checkabimod = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.vit?.valuebase ?? 0) +
+              (actorData.abilities?.vit?.valuegrowth ?? 0) +
+              (actorData.abilities?.vit?.valuemodify ?? 0) +
+              (actorData.abilities?.vit?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.vit?.efmodify ?? 0))
+          );
+        if (systemData.checkabi == "int")
+          checkabimod = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.int?.valuebase ?? 0) +
+              (actorData.abilities?.int?.valuegrowth ?? 0) +
+              (actorData.abilities?.int?.valuemodify ?? 0) +
+              (actorData.abilities?.int?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.int?.efmodify ?? 0))
+          );
+        if (systemData.checkabi == "mnd")
+          checkabimod = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.mnd?.valuebase ?? 0) +
+              (actorData.abilities?.mnd?.valuegrowth ?? 0) +
+              (actorData.abilities?.mnd?.valuemodify ?? 0) +
+              (actorData.abilities?.mnd?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.mnd?.efmodify ?? 0))
+          );
+        if (systemData.powerabi == "dex")
+          powerabimod = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.dex?.valuebase ?? 0) +
+              (actorData.abilities?.dex?.valuegrowth ?? 0) +
+              (actorData.abilities?.dex?.valuemodify ?? 0) +
+              (actorData.abilities?.dex?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.dex?.efmodify ?? 0))
+          );
+        if (systemData.powerabi == "agi")
+          powerabimod = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.agi?.valuebase ?? 0) +
+              (actorData.abilities?.agi?.valuegrowth ?? 0) +
+              (actorData.abilities?.agi?.valuemodify ?? 0) +
+              (actorData.abilities?.agi?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.agi?.efmodify ?? 0))
+          );
+        if (systemData.powerabi == "str")
+          powerabimod = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.str?.valuebase ?? 0) +
+              (actorData.abilities?.str?.valuegrowth ?? 0) +
+              (actorData.abilities?.str?.valuemodify ?? 0) +
+              (actorData.abilities?.str?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.str?.efmodify ?? 0))
+          );
+        if (systemData.powerabi == "vit")
+          powerabimod = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.vit?.valuebase ?? 0) +
+              (actorData.abilities?.vit?.valuegrowth ?? 0) +
+              (actorData.abilities?.vit?.valuemodify ?? 0) +
+              (actorData.abilities?.vit?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.vit?.efmodify ?? 0))
+          );
+        if (systemData.powerabi == "int")
+          powerabimod = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.int?.valuebase ?? 0) +
+              (actorData.abilities?.int?.valuegrowth ?? 0) +
+              (actorData.abilities?.int?.valuemodify ?? 0) +
+              (actorData.abilities?.int?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.int?.efmodify ?? 0))
+          );
+        if (systemData.powerabi == "mnd")
+          powerabimod = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.mnd?.valuebase ?? 0) +
+              (actorData.abilities?.mnd?.valuegrowth ?? 0) +
+              (actorData.abilities?.mnd?.valuemodify ?? 0) +
+              (actorData.abilities?.mnd?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.mnd?.efmodify ?? 0))
+          );
+      }
+      if (actor.type == "character" || actor.type == "npc" || actor.type == "monster") {
+        if (systemData.checkabi1 == "dex")
+          checkabimod1 = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.dex?.valuebase ?? 0) +
+              (actorData.abilities?.dex?.valuegrowth ?? 0) +
+              (actorData.abilities?.dex?.valuemodify ?? 0) +
+              (actorData.abilities?.dex?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.dex?.efmodify ?? 0))
+          );
+        if (systemData.checkabi1 == "agi")
+          checkabimod1 = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.agi?.valuebase ?? 0) +
+              (actorData.abilities?.agi?.valuegrowth ?? 0) +
+              (actorData.abilities?.agi?.valuemodify ?? 0) +
+              (actorData.abilities?.agi?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.agi?.efmodify ?? 0))
+          );
+        if (systemData.checkabi1 == "str")
+          checkabimod1 = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.str?.valuebase ?? 0) +
+              (actorData.abilities?.str?.valuegrowth ?? 0) +
+              (actorData.abilities?.str?.valuemodify ?? 0) +
+              (actorData.abilities?.str?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.str?.efmodify ?? 0))
+          );
+        if (systemData.checkabi1 == "vit")
+          checkabimod1 = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.vit?.valuebase ?? 0) +
+              (actorData.abilities?.vit?.valuegrowth ?? 0) +
+              (actorData.abilities?.vit?.valuemodify ?? 0) +
+              (actorData.abilities?.vit?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.vit?.efmodify ?? 0))
+          );
+        if (systemData.checkabi1 == "int")
+          checkabimod1 = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.int?.valuebase ?? 0) +
+              (actorData.abilities?.int?.valuegrowth ?? 0) +
+              (actorData.abilities?.int?.valuemodify ?? 0) +
+              (actorData.abilities?.int?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.int?.efmodify ?? 0))
+          );
+        if (systemData.checkabi1 == "mnd")
+          checkabimod1 = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.mnd?.valuebase ?? 0) +
+              (actorData.abilities?.mnd?.valuegrowth ?? 0) +
+              (actorData.abilities?.mnd?.valuemodify ?? 0) +
+              (actorData.abilities?.mnd?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.mnd?.efmodify ?? 0))
+          );
+        if (systemData.checkabi2 == "dex")
+          checkabimod2 = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.dex?.valuebase ?? 0) +
+              (actorData.abilities?.dex?.valuegrowth ?? 0) +
+              (actorData.abilities?.dex?.valuemodify ?? 0) +
+              (actorData.abilities?.dex?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.dex?.efmodify ?? 0))
+          );
+        if (systemData.checkabi2 == "agi")
+          checkabimod2 = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.agi?.valuebase ?? 0) +
+              (actorData.abilities?.agi?.valuegrowth ?? 0) +
+              (actorData.abilities?.agi?.valuemodify ?? 0) +
+              (actorData.abilities?.agi?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.agi?.efmodify ?? 0))
+          );
+        if (systemData.checkabi2 == "str")
+          checkabimod2 = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.str?.valuebase ?? 0) +
+              (actorData.abilities?.str?.valuegrowth ?? 0) +
+              (actorData.abilities?.str?.valuemodify ?? 0) +
+              (actorData.abilities?.str?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.str?.efmodify ?? 0))
+          );
+        if (systemData.checkabi2 == "vit")
+          checkabimod2 = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.vit?.valuebase ?? 0) +
+              (actorData.abilities?.vit?.valuegrowth ?? 0) +
+              (actorData.abilities?.vit?.valuemodify ?? 0) +
+              (actorData.abilities?.vit?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.vit?.efmodify ?? 0))
+          );
+        if (systemData.checkabi2 == "int")
+          checkabimod2 = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.int?.valuebase ?? 0) +
+              (actorData.abilities?.int?.valuegrowth ?? 0) +
+              (actorData.abilities?.int?.valuemodify ?? 0) +
+              (actorData.abilities?.int?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.int?.efmodify ?? 0))
+          );
+        if (systemData.checkabi2 == "mnd")
+          checkabimod2 = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.mnd?.valuebase ?? 0) +
+              (actorData.abilities?.mnd?.valuegrowth ?? 0) +
+              (actorData.abilities?.mnd?.valuemodify ?? 0) +
+              (actorData.abilities?.mnd?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.mnd?.efmodify ?? 0))
+          );
+        if (systemData.checkabi3 == "dex")
+          checkabimod3 = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.dex?.valuebase ?? 0) +
+              (actorData.abilities?.dex?.valuegrowth ?? 0) +
+              (actorData.abilities?.dex?.valuemodify ?? 0) +
+              (actorData.abilities?.dex?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.dex?.efmodify ?? 0))
+          );
+        if (systemData.checkabi3 == "agi")
+          checkabimod3 = Math.floor(
+            ((actorData.abilities?.dex?.racevalue ?? 0) +
+              (actorData.abilities?.agi?.valuebase ?? 0) +
+              (actorData.abilities?.agi?.valuegrowth ?? 0) +
+              (actorData.abilities?.agi?.valuemodify ?? 0) +
+              (actorData.abilities?.agi?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.agi?.efmodify ?? 0))
+          );
+        if (systemData.checkabi3 == "str")
+          checkabimod3 = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.str?.valuebase ?? 0) +
+              (actorData.abilities?.str?.valuegrowth ?? 0) +
+              (actorData.abilities?.str?.valuemodify ?? 0) +
+              (actorData.abilities?.str?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.str?.efmodify ?? 0))
+          );
+        if (systemData.checkabi3 == "vit")
+          checkabimod3 = Math.floor(
+            ((actorData.abilities?.str?.racevalue ?? 0) +
+              (actorData.abilities?.vit?.valuebase ?? 0) +
+              (actorData.abilities?.vit?.valuegrowth ?? 0) +
+              (actorData.abilities?.vit?.valuemodify ?? 0) +
+              (actorData.abilities?.vit?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.vit?.efmodify ?? 0))
+          );
+        if (systemData.checkabi3 == "int")
+          checkabimod3 = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.int?.valuebase ?? 0) +
+              (actorData.abilities?.int?.valuegrowth ?? 0) +
+              (actorData.abilities?.int?.valuemodify ?? 0) +
+              (actorData.abilities?.int?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.int?.efmodify ?? 0))
+          );
+        if (systemData.checkabi3 == "mnd")
+          checkabimod3 = Math.floor(
+            ((actorData.abilities?.int?.racevalue ?? 0) +
+              (actorData.abilities?.mnd?.valuebase ?? 0) +
+              (actorData.abilities?.mnd?.valuegrowth ?? 0) +
+              (actorData.abilities?.mnd?.valuemodify ?? 0) +
+              (actorData.abilities?.mnd?.efvaluemodify ?? 0)) /
+              6 +
+              Number((actorData.abilities?.mnd?.efmodify ?? 0))
+          );
+      }
+  
     systemData.checkbase =
       Number(systemData.checkmod) + Number(checklevelmod) + Number(checkabimod);
     systemData.powerbase =
@@ -1010,6 +1014,11 @@ export class SW25Item extends Item {
       if (systemData.pwmrbt) systemData.powerTypesButton.push("mr");
     }
 
+    if (itemData.type == "raceability") {
+      const result = Number(systemData.basempcost) - Number(actorData.attributes.efmpall);
+      systemData.mpcost = isNaN(result) ? null : (result <= 0 ? 1 : result);
+    }
+    
     if (itemData.type == "weapon") {
       systemData.checkbase =
         Number(systemData.checkbase) +
@@ -1280,23 +1289,33 @@ export class SW25Item extends Item {
           case effectVitResMon:
             if (actorData.effect.vitres)
               systemData.efmod = Number(actorData.effect.vitres);
+            systemData.efmod += Math.floor((actorData.abilities?.vit?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.vit?.efmodify ?? 0);
             break;
           case effectMndResMon:
             if (actorData.effect.mndres)
               systemData.efmod = Number(actorData.effect.mndres);
+            systemData.efmod += Math.floor((actorData.abilities?.mnd?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.mnd?.efmodify ?? 0);
             break;
           case effectHitMon:
             if (actorData.attributes.efhitmod)
               systemData.efmod = Number(actorData.attributes.efhitmod);
+            systemData.efmod += Math.floor((actorData.abilities?.dex?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.dex?.efmodify ?? 0);
             break;
           case effectDmgMon:
             if (actorData.attributes.efdmod)
               systemData.efmod = Number(actorData.attributes.efdmod);
+            systemData.efmod += Math.floor((actorData.abilities?.str?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.str?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectDodgeMon:
             if (actorData.attributes.efdodgemod)
               systemData.efmod = Number(actorData.attributes.efdodgemod);
+            systemData.efmod += Math.floor((actorData.abilities?.agi?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.agi?.efmodify ?? 0);
             break;
           case effectScpMon:
             if (actorData.attributes.efscmod)
@@ -1304,6 +1323,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efscmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectCnpMon:
@@ -1312,6 +1333,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efcnmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectWzpMon:
@@ -1320,6 +1343,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efwzmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectPrpMon:
@@ -1328,6 +1353,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efprmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectMtpMon:
@@ -1336,6 +1363,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efmtmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectFrpMon:
@@ -1344,6 +1373,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.effrmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectDrpMon:
@@ -1352,6 +1383,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efdrmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectDmpMon:
@@ -1360,6 +1393,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efdmmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           case effectAbpMon:
@@ -1368,6 +1403,8 @@ export class SW25Item extends Item {
                 Number(actorData.attributes.efabmod) +
                 Number(systemData.efallmgpmod);
             else systemData.efmod = Number(systemData.efallmgpmod);
+            systemData.efmod += Math.floor((actorData.abilities?.int?.efvaluemodify ?? 0) / 6);
+            systemData.efmod += Number(actorData.abilities?.int?.efmodify ?? 0);
             systemData.efallckmod = 0;
             break;
           default:
@@ -1751,6 +1788,8 @@ export class SW25Item extends Item {
       systemData.resource.isLifeline = true;
     } else if (systemData?.resource.type == "tacspower") {
       systemData.resource.isTacsPower = true;
+    } else if (systemData?.resource.type == "magitech") {
+      systemData.resource.isMagitech = true;
     } else if (systemData?.resource.type == "abyssex") {
       systemData.resource.isAbyssEx = true;
     } else {
@@ -1758,6 +1797,7 @@ export class SW25Item extends Item {
       systemData.resource.isMaterial = false;
       systemData.resource.isLifeline = false;
       systemData.resource.isTacsPower = false;
+      systemData.resource.isMagitech = false;
       systemData.resource.isAbyssEx = false;
     }
 
@@ -2251,6 +2291,14 @@ export class SW25Item extends Item {
         systemData.actionresult = 0;
         break;
     }
+  }
+
+  _prepareSessionData(itemData) {
+    if (itemData.type !== "session") return;
+
+    // Make modifications to data here. For example:
+    //const systemData = itemData.system;
+
   }
 
   /**

--- a/module/helpers/rollrequest.mjs
+++ b/module/helpers/rollrequest.mjs
@@ -87,6 +87,7 @@ export async function rollreq() {
               mod = modifier > 0 ? `+${modifier}` : modifier;
             }
 
+            console.log(chatData)
             chatData.content = await renderTemplate(
               "systems/sw25/templates/roll/rollreq-card.hbs",
               {
@@ -102,6 +103,7 @@ export async function rollreq() {
         },
         cancel: { label: game.i18n.localize("Cancel") },
       },
+      default: "buttonloot",
       render: (html) => {
         html.find('input[name="method"]').change(async (event) => {
           method = event.target.value;

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -44,10 +44,12 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/sw25/templates/actor/parts/actor-effects.hbs",
     "systems/sw25/templates/actor/parts/actor-monsterabilities.hbs",
     "systems/sw25/templates/actor/parts/actor-monsterspells.hbs",
+    "systems/sw25/templates/actor/parts/actor-monsterskills.hbs",
     "systems/sw25/templates/actor/parts/actor-actions.hbs",
     "systems/sw25/templates/actor/parts/actor-actions-fellow.hbs",
     "systems/sw25/templates/actor/parts/actor-actions-daemon.hbs",
     // Item partials
+    "systems/sw25/templates/item/parts/item-customs.hbs",
     "systems/sw25/templates/item/parts/item-effects.hbs",
     "systems/sw25/templates/item/parts/item-usepower.hbs",
     "systems/sw25/templates/item/parts/item-usedice.hbs",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -168,6 +168,7 @@ export class SW25ActorSheet extends ActorSheet {
     };
     const lifelines = [];
     const tacspowers = [];
+    const magitechrs = [];
     const abyssexs = [];
     let materialshow = {
       all: false,
@@ -214,6 +215,8 @@ export class SW25ActorSheet extends ActorSheet {
           lifelines.push(i);
         } else if (i.system?.resource?.type == "tacspower") {
           tacspowers.push(i);
+        } else if (i.system?.resource?.type == "magitech") {
+          magitechrs.push(i);
         } else if (i.system?.resource?.type == "abyssex") {
           abyssexs.push(i);
         }
@@ -571,11 +574,13 @@ export class SW25ActorSheet extends ActorSheet {
     context.materials = materials;
     context.lifelines = lifelines;
     context.tacspowers = tacspowers;
+    context.magitechrs = magitechrs;
     context.abyssexs = abyssexs;
     context.noteshow = notes.length > 0;
     context.materialshow = materialshow;
     context.lifelineshow = lifelines.length > 0;
     context.tacspowershow = tacspowers.length > 0;
+    context.magitechrshow = magitechrs.length > 0;
     context.abyssexshow = abyssexs.length > 0;
   }
 
@@ -1319,7 +1324,7 @@ export class SW25ActorSheet extends ActorSheet {
       : game.i18n.localize("SW25.Monster.Unidentifiedmon");
     monsterName += `(${this.actor.system.type})`;
     targetValue = this.actor.system.popularity;
-    targetValue += Number.isFinite(this.actor.system.weakpoint)
+    targetValue += !isNaN(Number(this.actor.system.weakpoint))
       ? "/" + this.actor.system.weakpoint
       : "";
 
@@ -2079,7 +2084,7 @@ export class SW25ActorSheet extends ActorSheet {
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
     let label = game.i18n.localize("SW25.Effectslong");
     let chatActorName = ">>> " + selectedTokens[0].actor.name + "<br>";
-    let chatEffectName = effects[0].name + game.i18n.localize(`SW25.Item.Phasearea.${lifeline}`) + "<br>";
+    let chatEffectName = effects[0].name + "(" + game.i18n.localize(`SW25.Item.Phasearea.${lifeline}`) + ")<br>";
 
     let chatData = {
       speaker: speaker,

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -2061,23 +2061,6 @@ export class SW25ActorSheet extends ActorSheet {
       await resource.update({ "system.quantity": newVal });
     }
 
-    if (item.system.type == "ten") {
-      let val = this.actor.system.attributes.qi.heaven.value - cost;
-      this.actor.update({
-        "system.attributes.qi.heaven.value": val,
-      });
-    } else if (item.system.type == "chi") {
-      let val = this.actor.system.attributes.qi.earth.value - cost;
-      this.actor.update({
-        "system.attributes.qi.earth.value": val,
-      });
-    } else if (item.system.type == "jin") {
-      let val = this.actor.system.attributes.qi.spirit.value - cost;
-      this.actor.update({
-        "system.attributes.qi.spirit.value": val,
-      });
-    }
-
     // Apply
     if (game.user.isGM) {
       selectedTokens[0].actor.createEmbeddedDocuments("ActiveEffect", effects);

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -162,6 +162,11 @@ export class SW25ItemSheet extends ItemSheet {
       this._prepareActionData(context);
     }
 
+    if (itemData.type == "session") {
+      this._prepareItemRollData(context);
+      this._prepareSessionData(context);
+    }
+
     // Retrieve the roll data for TinyMCE editors.
     context.rollData = this.item.getRollData();
 
@@ -195,6 +200,7 @@ export class SW25ItemSheet extends ItemSheet {
   _prepareSpellData(context) {}
   _prepareMonsterabilityData(context) {}
   _prepareActionData(context) {}
+  _prepareSessionData(context) {}
 
   /* -------------------------------------------- */
 
@@ -211,5 +217,184 @@ export class SW25ItemSheet extends ItemSheet {
     html.on("click", ".effect-control", (ev) =>
       onManageActiveEffect(ev, this.item)
     );
+
+    // Session Result.
+    html.on("click", ".session-result", this._onSessionResult.bind(this));
+
+    // Add Field.
+    html.find(".add-field").click((ev) => {
+      ev.preventDefault();
+      const fields = duplicate(this.item.system.customFields || []);
+      fields.push({ label: "", value: "" });
+      this.item.update({ "system.customFields": fields });
+    });
+
+    // Delete Field.
+    html.find(".remove-field").click((ev) => {
+      ev.preventDefault();
+      const idx = Number(ev.currentTarget.dataset.idx);
+      //const fields = duplicate(this.item.system.customFields || []);
+      let fieldsRaw = this.item.system.customFields;
+      let fields = Array.isArray(fieldsRaw)
+        ? duplicate(fieldsRaw)
+        : Object.values(duplicate(fieldsRaw));
+      fields.splice(idx, 1);
+      this.item.update({ "system.customFields": fields });
+    });
+
+    // Move up.
+    html.find(".move-up").click((ev) => {
+      ev.preventDefault();
+      const idx = Number(ev.currentTarget.dataset.idx);
+      let fieldsRaw = this.item.system.customFields;
+      let fields = Array.isArray(fieldsRaw)
+        ? duplicate(fieldsRaw)
+        : Object.values(duplicate(fieldsRaw));
+      if (idx > 0) {
+        [fields[idx - 1], fields[idx]] = [fields[idx], fields[idx - 1]];
+        this.item.update({ "system.customFields": fields });
+      }
+    });
+
+    // Move down.
+    html.find(".move-down").click((ev) => {
+      ev.preventDefault();
+      const idx = Number(ev.currentTarget.dataset.idx);
+      let fieldsRaw = this.item.system.customFields;
+      let fields = Array.isArray(fieldsRaw)
+        ? duplicate(fieldsRaw)
+        : Object.values(duplicate(fieldsRaw));
+      if (idx < fields.length - 1) {
+        [fields[idx], fields[idx + 1]] = [fields[idx + 1], fields[idx]];
+        this.item.update({ "system.customFields": fields });
+      }
+    });
+  }
+
+  async _onSessionResult(event) {
+    event.preventDefault();
+
+    const item = this.item;
+    let chatData = null;
+    let roll = null;
+    let formula = null;
+    let tooltip = null;
+    let total = null;
+    let isRoll = false;
+
+    const label = game.i18n.localize("SW25.Item.Session.Result.Label");
+
+    const title = item.name;
+    const pcNum = Number(item.system.session.pcnum);
+
+    const gamel =
+      Number(item.system.session.mission.gamel) +
+      Number(item.system.session.middle.gamel);
+    const keepGamel = gamel % pcNum;
+    const getGamel = Math.floor((gamel - keepGamel) / pcNum);
+
+    let getExp =
+      Number(item.system.session.mission.exp) +
+      Number(item.system.session.middle.exp);
+
+    const abyss = Number(item.system.session.middle.abyss);
+    const keepAbyss = abyss % pcNum;
+    const getAbyss = Math.floor((abyss - keepAbyss) / pcNum);
+    const getTresure = Number(item.system.session.middle.tresure);
+
+    const getSword = Number(item.system.session.middle.sword);
+
+    let getHonor = Number(item.system.session.mission.honor);
+
+    // basic info.
+    const isBasic = item.system.result.character;
+    const date = item.system.session.date;
+    const gm = item.system.session.gamemaster;
+    const player = item.system.session.player;
+
+    // character result.
+    let characterNames = item.system.result.character
+      ? canvas.tokens.placeables
+          .filter((token) => token.actor?.type === "character")
+          .map((token) => token.name)
+      : [];
+
+    let isCharaExp = false;
+    let charaResult = [];
+    if (0 < characterNames.length) {
+      isCharaExp = true;
+      for (let name of characterNames) {
+        const targetActor = game.actors.find((a) => a.name === name);
+        if (targetActor) {
+          const oneRollValue = targetActor.system.attributes.fumble ?? 0;
+          charaResult.push({name: name, value: oneRollValue});
+        }
+      }
+    }
+
+    // custom items.
+    const isCustom = item.system.result.custom;
+    const fieldsRaw = item.system.customFields;
+    console.log(fieldsRaw);
+    const customItems = Object.values(fieldsRaw);
+    console.log(customItems);
+
+    // sword shard result.
+    if (item.system.result.sword && 0 < getSword) {
+      isRoll = true;
+      formula = getSword + "d6";
+      roll = new Roll(formula);
+      await roll.evaluate({ async: true });
+      tooltip = await roll.getTooltip();
+      total= roll.total;
+
+      getHonor += Number(roll.total);
+      chatData = {
+        speaker: ChatMessage.getSpeaker(),
+        flavor: label,
+        type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+        rolls: [roll],
+      };
+    } else {
+      chatData = {
+        speaker: ChatMessage.getSpeaker(),
+        flavor: label,
+      };
+    }
+    const isGamel = (0 < getGamel || 0 < keepGamel);
+    const isHonor = (0 < getHonor || 0 < getSword);
+    const isAbyss = (0 < getAbyss || 0 < keepAbyss);
+
+    chatData.content = await renderTemplate(
+      "systems/sw25/templates/roll/session-info.hbs",
+      {
+        title: title,
+        isGamel: isGamel,
+        getGamel: getGamel,
+        keepGamel: keepGamel,
+        getExp: getExp,
+        isHonor: isHonor,
+        getHonor: getHonor,
+        getSword: getSword,
+        isAbyss: isAbyss,
+        getAbyss: getAbyss,
+        keepAbyss: keepAbyss,
+        getTresure: getTresure,
+        isBasic: isBasic,
+        date: date,
+        gm: gm,
+        player: player,
+        isCharaExp: isCharaExp,
+        charaResult: charaResult,
+        isCustom: isCustom,
+        customItems: customItems,
+        isRoll: isRoll,
+        formula: formula,
+        tooltip: tooltip,
+        total: total,
+      }
+    );
+
+    ChatMessage.create(chatData);
   }
 }

--- a/template.json
+++ b/template.json
@@ -424,7 +424,7 @@
     }
   },
   "Item": {
-    "types": ["weapon", "armor", "accessory", "item", "spell", "enhancearts", "magicalsong", "ridingtrick", "alchemytech", "phasearea", "tactics", "infusion", "barbarousskill", "essenceweave", "otherfeature", "check", "resource", "combatability", "skill", "raceability", "language", "monsterability", "action"],
+    "types": ["weapon", "armor", "accessory", "item", "spell", "enhancearts", "magicalsong", "ridingtrick", "alchemytech", "phasearea", "tactics", "infusion", "barbarousskill", "essenceweave", "otherfeature", "check", "resource", "combatability", "skill", "raceability", "language", "monsterability", "action", "session"],
     "templates": {
       "base": {
         "description": "",
@@ -642,7 +642,7 @@
       "checkmethod": "normal",
       "efckmod": 0,
       "efallckmod": 0
-  },
+    },
     "resource": {
       "templates": ["base", "item", "roll"]
     },
@@ -766,7 +766,11 @@
       "target": "",
       "basempcost": "",
       "mpcost": ""
-  },
+    },
+    "session": {
+      "templates": ["base", "roll"],
+      "character": 1
+    },
     "otherfeature": {
       "templates": ["base", "roll"],
       "type": "",

--- a/templates/actor/actor-monster-sheet.hbs
+++ b/templates/actor/actor-monster-sheet.hbs
@@ -143,6 +143,9 @@
         <div>
           {{> "systems/sw25/templates/actor/parts/actor-monsterspells.hbs"}}
         </div>
+        <div>
+          {{> "systems/sw25/templates/actor/parts/actor-monsterskills.hbs"}}
+        </div>
         {{/if}}
       </div>
 

--- a/templates/actor/parts/actor-monsterskills.hbs
+++ b/templates/actor/parts/actor-monsterskills.hbs
@@ -1,20 +1,20 @@
 <ol class='items-list'>
   <li class='item flexrow items-header'>
-    <div class='item-name'>{{localize "TYPES.Item.raceability"}}</div>
+    <div class='item-name'>{{localize "TYPES.Item.enhancearts"}}</div>
     <div class='item-element' style="flex: 0 0 50px;">MP</div>
-    <div class='item-quantity item-element' style="flex: 0 0 60px;">{{localize "SW25.Item.Rest"}}</div>
+    <div class='item-element' style="flex: 0 0 100px;">{{localize "SW25.Time"}}</div>
     <div class='item-controls'>
       <a
         class='item-control item-create'
-        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.raceability")}}'
-        data-type='raceability'
+        title='{{localize "DOCUMENT.Create" type=(localize "TYPES.Item.enhancearts")}}'
+        data-type='enhancearts'
       >
         <i class='fas fa-plus'></i>
         {{localize 'DOCUMENT.New' type=''}}
       </a>
     </div>
   </li>
-  {{#each raceabilities as |item id|}}
+  {{#each enhancearts as |item id|}}
     <li class='item' data-item-id='{{item._id}}'>
       <div class="flexrow flex-group-center">
         <div class='item-name'>
@@ -28,7 +28,7 @@
               />
             </a>
           </div>
-          <h4 class="item-label">{{item.name}}</h4>
+          {{#if system.aux}}≫{{/if}}{{#if system.prep}}△{{/if}}<h4 class="item-label">{{item.name}}</h4>
         </div>
         <div class="rollable" style="flex: 0 0 40px; display: {{#if system.usedice}}block{{else}}none{{/if}};" data-roll="{{item.system.checkformula}}+{{item.system.checkbase}}" data-label="{{item.name}} ({{localize "SW25.Check"}})" data-pt="{{item.system.powertable}}" data-apply="{{system.applycheck}}" data-checktype="{{system.checkTypesButton}}">
           <b>{{localize "SW25.Item.CheckB"}}</b>
@@ -42,29 +42,19 @@
         <div class='mpcost item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 50px;" data-cost="{{item.system.mpcost}}" data-label="{{item.name}}" data-type="{{item.type}}">
           {{system.mpcost}}
         </div>
-        <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 60px;">
-{{!--
-          <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
-            <i class="fas fa-minus"></i>
-          </a>
---}}
-          <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
-{{!--
-          <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
-            <i class="fas fa-plus"></i>
-          </a>
---}}
+        <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 100px;">
+          {{system.time}} 
         </div>
         <div class='item-controls'>
           <a
             class='item-control item-edit'
-            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.raceability")}}'
+            title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.enhancearts")}}'
           >
             <i class='fas fa-edit'></i>
           </a>
           <a
             class='item-control item-delete'
-            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.raceability")}}'
+            title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.enhancearts")}}'
           >
             <i class='fas fa-trash'></i>
           </a>

--- a/templates/actor/parts/actor-spells-magitech.hbs
+++ b/templates/actor/parts/actor-spells-magitech.hbs
@@ -1,4 +1,40 @@
 <ol class='items-list'>
+  {{#if magitechrshow}}
+    <div class='item flexrow items-header'>
+      <div class='item-name'>{{localize "SW25.Item.Resource.Types.Magitech"}}</div>
+    </div>
+    <div class='item flexrow ability-resource'>
+      <div class='item-name'>
+        {{#each magitechrs as |item id|}}
+          <li class='item' data-item-id='{{item._id}}'>
+            <div>
+              <div class="item-prop flexrow flex-group-center">
+                <h4 class="item-label">{{item.name}}</h4>
+              </div>
+              <div class='item-quantity item-prop flexrow flex-group-center' style="flex: 0 0 80px;">
+                <a class="quantity-button" data-action="decrease" data-property="item.system.quantity">
+                  <i class="fas fa-minus"></i>
+                </a>
+                <input class="qt-change" type="text" name="quantityInput" value="{{item.system.quantity}}" data-dtype="Number"/>
+                <a class="quantity-button" data-action="increase" data-property="item.system.quantity">
+                  <i class="fas fa-plus"></i>
+                </a>
+              </div>
+              <div class='item-controls'>
+                <a class='item-control item-edit' title='{{localize "DOCUMENT.Update" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-edit'></i>
+                </a>
+                <a class='item-control item-delete' title='{{localize "DOCUMENT.Delete" type=(localize "TYPES.Item.resource")}}'>
+                  <i class='fas fa-trash'></i>
+                </a>
+              </div>
+            </div>
+          </li>
+        {{/each}}
+      </div>
+      <div class='item-element' style="flex: 0 0 240px;">&nbsp;</div>
+    </div>
+  {{/if}}
   <li class='item flexrow items-header'>
     <div class='item-element' style="flex: 0 0 30px;">Lv</div>
     <div class='item-name'>{{localize "SW25.Item.Spell.Magitech"}}</div>

--- a/templates/item/item-raceability-sheet.hbs
+++ b/templates/item/item-raceability-sheet.hbs
@@ -43,7 +43,10 @@
               {{/select}}
             </select>
           </span>
-          <div class="grid-span-3"></div>
+          <div class="grid-span-3">
+          <span class="grid-span-2" style="text-align: center;"><label for="{{item._id}}system.basempcost"><b>MP{{localize "SW25.Cost"}}</b></label><br>
+            <input id="{{item._id}}system.basempcost" style="max-width: calc(50% - 7px);" type="text" name="system.basempcost" value="{{system.basempcost}}" data-dtype="Number"/></span>
+          </div>
           <span class="grid-span-2"  style="text-align: center;"><label for="{{item._id}}system.usedice"><b>{{localize "SW25.Item.Usedice"}}</b></label><br>
             <input id="{{item._id}}system.usedice" type="checkbox" name="system.usedice" data-dtype="Boolean" {{#if system.usedice}} checked {{/if}}/></span>
           <span class="grid-span-2"  style="text-align: center;"><label for="{{item._id}}system.usepower"><b>{{localize "SW25.Item.Usepower"}}</b></label><br>

--- a/templates/item/item-resource-sheet.hbs
+++ b/templates/item/item-resource-sheet.hbs
@@ -63,6 +63,7 @@
               <option value="material">{{localize "SW25.Item.Resource.Types.Material"}}</option>
               <option value="lifeline">{{localize "SW25.Item.Resource.Types.Lifeline"}}</option>
               <option value="tacspower">{{localize "SW25.Item.Resource.Types.Tacspower"}}</option>
+              <option value="magitech">{{localize "SW25.Item.Resource.Types.Magitech"}}</option>
               <option value="abyssex">{{localize "SW25.Item.Resource.Types.AbyssEx"}}</option>
               {{/select}}
             </select>
@@ -104,6 +105,17 @@
               <option value="ten">{{localize "SW25.Item.Phasearea.Ten"}}</option>
               <option value="chi">{{localize "SW25.Item.Phasearea.Chi"}}</option>
               <option value="jin">{{localize "SW25.Item.Phasearea.Jin"}}</option>
+              {{/select}}
+            </select>
+          </div>
+          <div class="grid-span-3" style="display: {{#if system.resource.isMagitech}}block{{else}}none{{/if}}; text-align: center;">
+            <b>{{localize "SW25.Item.Resource.Types.Magitech"}}</b><br>
+            <select name="system.resource.magitechtype">
+              {{#select system.resource.magitechtype}}
+              <option value="bullet">{{localize "SW25.Item.Resource.Bullet"}}</option>
+              <option value="magisphereS">{{localize "SW25.Item.Resource.MagisphereS"}}</option>
+              <option value="magisphereM">{{localize "SW25.Item.Resource.MagisphereM"}}</option>
+              <option value="magisphereL">{{localize "SW25.Item.Resource.MagisphereL"}}</option>
               {{/select}}
             </select>
           </div>

--- a/templates/item/item-session-sheet.hbs
+++ b/templates/item/item-session-sheet.hbs
@@ -1,0 +1,118 @@
+<form class="{{cssClass}}" autocomplete="off">
+  <header class="sheet-header">
+    <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+    <div class="header-fields">
+      <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
+      <div class="grid grid-6col flex-group-left nogapmargin">
+        <div class="grid-span-2">
+          <div class="session-result">{{localize "SW25.Item.Session.OutputResult"}}</div>
+        </div>
+        <div class="grid-span-1 session-result-title">
+          <label for="{{item._id}}system.result.basic" class="nobreak">{{localize "SW25.Item.Session.BasicResult"}}</label><br>
+          <input id="{{item._id}}system.result.basic" type="checkbox" name="system.result.basic" {{checked system.result.basic}} data-dtype="Boolean" class="basic" />
+        </div>
+        <div class="grid-span-1 session-result-title">
+          <label for="{{item._id}}system.result.sword" class="nobreak">{{localize "SW25.Item.Session.SwordResult"}}</label><br>
+          <input id="{{item._id}}system.result.sword" type="checkbox" name="system.result.sword" {{checked system.result.sword}} data-dtype="Boolean" class="sword" />
+        </div>
+        <div class="grid-span-1 session-result-title">
+          <label for="{{item._id}}system.result.character" class="nobreak">{{localize "SW25.Item.Session.CharaResult"}}</label><br>
+          <input id="{{item._id}}system.result.character" type="checkbox" name="system.result.character" {{checked system.result.character}} data-dtype="Boolean" class="character" />
+        </div>
+        <div class="grid-span-1 session-result-title">
+          <label for="{{item._id}}system.result.custom" class="nobreak">{{localize "SW25.Item.Session.CustomResult"}}</label><br>
+          <input id="{{item._id}}system.result.custom" type="checkbox" name="system.result.custom" {{checked system.result.custom}} data-dtype="Boolean" class="custom" />
+        </div>
+      </div>
+    </div>
+  </header>
+
+  {{!-- Sheet Tab Navigation --}}
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <a class="item" data-tab="description">{{localize "SW25.Description"}}</a>
+    <a class="item" data-tab="details">{{localize "SW25.Details"}}</a>
+    <a class="item" data-tab="customs">{{localize "SW25.Customs"}}</a>
+  </nav>
+
+  {{!-- Sheet Body --}}
+  <section class="sheet-body">
+
+    {{!-- Description Tab --}}
+    <div class="tab" data-group="primary" data-tab="description">
+      {{editor system.description target="system.description" rollData=rollData button=true owner=owner editable=editable}}
+    </div>
+
+    {{!-- Detail Tab --}}
+    <div class="tab details" data-group="primary" data-tab="details">
+      <div class="flexcol">
+
+        <fieldset class="target-select">
+          <legend id="session-info">
+            <span class="session-title">{{localize "SW25.Item.Session.Information"}}</span>
+          </legend>
+
+          <div class="flexrow grid grid-10col session-detail">
+            <span class="grid-span-2" style="text-align: left;"><label for="{{item._id}}system.session.date"><b>{{localize "SW25.Item.Session.Date"}}</b></label><br>
+              <input id="{{item._id}}system.session.date" type="text" name="system.session.date" value="{{system.session.date}}" data-dtype="String"/></span>
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.gamemaster"><b>{{localize "SW25.Item.Session.GM"}}</b></label><br>
+              <input id="{{item._id}}system.session.gamemaster" type="text" name="system.session.gamemaster" value="{{system.session.gamemaster}}" data-dtype="String"/></span>
+            <span class="grid-span-1" style="text-align: left;"><label for="{{item._id}}system.session.pcnum"><b>{{localize "SW25.Item.Session.PC"}}</b></label><br>
+              <input id="{{item._id}}system.session.pcnum" type="number" name="system.session.pcnum" value="{{system.session.pcnum}}" data-dtype="String"/></span>
+            <span class="grid-span-4" style="text-align: left;"></span>
+
+            <span class="grid-span-10" style="text-align: left;"><label for="{{item._id}}system.session.player"><b>{{localize "SW25.Item.Session.Player"}}</b></label><br>
+              <input id="{{item._id}}system.session.player" type="text" name="system.session.player" value="{{system.session.player}}" data-dtype="String"/></span>
+          </div>
+        </fieldset>
+
+        <fieldset class="target-select">
+          <legend id="session-info">
+            <span class="session-title">{{localize "SW25.Item.Session.Mission"}}</span>
+          </legend>
+
+          <div class="flexrow grid grid-10col session-detail">
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.mission.exp"><b>{{localize "SW25.Item.Session.Exp"}}</b></label><br>
+              <input id="{{item._id}}system.session.mission.exp" type="number" name="system.session.mission.exp" value="{{system.session.mission.exp}}" data-dtype="String"/></span>
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.mission.gamel"><b>{{localize "SW25.Item.Session.Gamel"}}</b></label><br>
+              <input id="{{item._id}}system.session.mission.gamel" type="number" name="system.session.mission.gamel" value="{{system.session.mission.gamel}}" data-dtype="String"/></span>
+            <span class="grid-span-2" style="text-align: left;"><label for="{{item._id}}system.session.mission.honor"><b>{{localize "SW25.Item.Session.Honor"}}</b></label><br>
+              <input id="{{item._id}}system.session.mission.honor" type="number" name="system.session.mission.honor" value="{{system.session.mission.honor}}" data-dtype="String"/></span>
+            <span class="grid-span-2" style="text-align: left;"></span>
+
+          </div>
+        </fieldset>
+
+        <fieldset class="target-select">
+          <legend id="session-info">
+            <span class="session-title">{{localize "SW25.Item.Session.Middle"}}</span>
+          </legend>
+
+          <div class="flexrow grid grid-10col session-detail">
+
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.middle.exp"><b>{{localize "SW25.Item.Session.Exp"}}</b></label><br>
+              <input id="{{item._id}}system.session.middle.exp" type="number" name="system.session.middle.exp" value="{{system.session.middle.exp}}" data-dtype="String"/></span>
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.middle.gamel"><b>{{localize "SW25.Item.Session.Gamel"}}</b></label><br>
+              <input id="{{item._id}}system.session.middle.gamel" type="number" name="system.session.middle.gamel" value="{{system.session.middle.gamel}}" data-dtype="String"/></span>
+            <span class="grid-span-2" style="text-align: left;"><label for="{{item._id}}system.session.middle.sword"><b>{{localize "SW25.Item.Session.Sword"}}</b></label><br>
+              <input id="{{item._id}}system.session.middle.sword" type="number" name="system.session.middle.sword" value="{{system.session.middle.sword}}" data-dtype="String"/></span>
+            <span class="grid-span-2" style="text-align: left;"></span>
+
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.middle.abyss"><b>{{localize "SW25.Item.Session.Abyss"}}</b></label><br>
+              <input id="{{item._id}}system.session.middle.abyss" type="number" name="system.session.middle.abyss" value="{{system.session.middle.abyss}}" data-dtype="String"/></span>
+            <span class="grid-span-3" style="text-align: left;"><label for="{{item._id}}system.session.middle.tresure"><b>{{localize "SW25.Item.Session.Tresure"}}</b></label><br>
+              <input id="{{item._id}}system.session.middle.tresure" type="number" name="system.session.middle.tresure" value="{{system.session.middle.tresure}}" data-dtype="String"/></span>
+            <span class="grid-span-4" style="text-align: left;"></span>
+          </div>
+        </fieldset>
+
+      </div>
+    </div>
+
+
+    {{!-- Effects Tab --}}
+    <div class="tab customs" data-group="primary" data-tab="customs">
+      {{> "systems/sw25/templates/item/parts/item-customs.hbs"}}
+    </div>
+
+  </section>
+</form>

--- a/templates/item/parts/item-customs.hbs
+++ b/templates/item/parts/item-customs.hbs
@@ -1,0 +1,35 @@
+<ol class="items-list custom-list">
+  <li class="items-header flexrow">
+    <div class="custom-name" data-idx="{{idx}}">
+      <h3 class="item-name">{{localize "SW25.Customs"}}</h3>
+    </div>
+    <div class="custom-value">{{localize "SW25.Custom.Value"}}</div>
+    <div class="item-controls custom-controls flexrow"  style="flex: 0 0 70px;">
+      <a class="add-field" title="{{localize "SW25.Adding"}}">
+        <i class="fas fa-plus"></i> {{localize "DOCUMENT.New" type=""}}
+      </a>
+    </div>
+  </li>
+
+  {{#each system.customFields as |field idx|}}
+  <li class="item custom flexrow" data-effect-id="{{effect.id}}" data-parent-id="{{effect.parent.id}}">
+    <div class="custom-name" data-idx="{{idx}}">
+      <input type="text" name="system.customFields.{{idx}}.label" value="{{field.label}}" placeholder="{{localize "SW25.Custom.Name"}}" />
+    </div>
+    <div class="custom-value" data-idx="{{idx}}">
+      <input type="text" name="system.customFields.{{idx}}.value" value="{{field.value}}" placeholder="{{localize "SW25.Custom.Value"}}" />
+    </div>
+    <div class="item-controls custom-controls flexrow"  style="flex: 0 0 70px;">
+      <a class="move-up" data-idx="{{idx}}" title="{{localize "SW25.Custom.MoveUp"}}">
+        <i class="fa-solid fa-arrow-up"></i>
+      </a>
+      <a class="move-down" data-idx="{{idx}}" title="{{localize "SW25.Custom.MoveDown"}}">
+        <i class="fa-solid fa-arrow-down"></i>
+      </a>
+      <a class="remove-field" data-idx="{{idx}}" title="{{localize "SW25.Custom.Delete"}}">
+        <i class="fas fa-trash"></i>
+      </a>
+    </div>
+  </li>
+  {{/each}}
+</ol>

--- a/templates/roll/session-info.hbs
+++ b/templates/roll/session-info.hbs
@@ -1,0 +1,107 @@
+<div class="session-result-chat">
+    <div class="title">{{title}}</div>
+
+    {{#if isBasic}}
+    <div class="basic-info">
+        {{#if date}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Date"}}:{{date}}
+            </div>
+        {{/if}}
+        {{#if gm}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.GM"}}:{{gm}}
+            </div>
+        {{/if}}
+        {{#if player}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Player"}}:{{player}}
+            </div>
+        {{/if}}
+    </div>
+    {{/if}}
+
+    <div class="session-info">
+        {{#if getExp}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Exp"}}:{{getExp}}
+            </div>
+        {{/if}}
+        {{#if isGamel}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Gamel"}}:{{getGamel}}
+            {{#if keepGamel}} ({{localize "SW25.Item.Session.Result.Remainder"}}:{{keepGamel}}){{/if}}
+            </div>
+        {{/if}}
+        {{#if isHonor}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Honor"}}:{{getHonor}}
+            {{#if getSword}} ({{localize "SW25.Item.Session.Sword"}}:{{getSword}}){{/if}}
+            </div>
+        {{/if}}
+        {{#if isAbyss}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Abyss"}}:{{getAbyss}}
+            {{#if keepAbyss}} ({{localize "SW25.Item.Session.Result.Remainder"}}:{{keepAbyss}}){{/if}}
+            </div>
+        {{/if}}
+        {{#if getTresure}}
+            <div class="contents">
+            {{localize "SW25.Item.Session.Tresure"}}:{{getTresure}}
+            </div>
+        {{/if}}
+        </div>
+
+        {{#if isCharaExp}}
+        <div class="character-info">
+            <table>
+                <tr>
+                    <th class="header-title"><div>{{localize "SW25.Item.Session.Result.Character"}}</div></th>
+                    <th class="header-value"><div></div>{{localize "SW25.Item.Session.Result.Fumble"}}</div></th>
+                </tr>
+                {{#each charaResult}}
+                <tr>
+                    <td class="contents-title"><div>{{name}}</div></td>
+                    <td class="contents-value"><div>{{value}}</div></td>
+                </tr>
+                {{/each}}
+            </table>
+        </div>
+        {{/if}}
+
+        {{#if isCustom}}
+        <div class="custom-info">
+            <table>
+                <tr>
+                    <th class="header-title"><div>{{localize "SW25.Item.Session.Result.Item"}}</div></th>
+                    <th class="header-value"><div>{{localize "SW25.Item.Session.Result.Value"}}</div></th>
+                </tr>
+                {{#each customItems}}
+                <tr>
+                    <td class="contents-title"><div>{{label}}</div></td>
+                    <td class="contents-value"><div>{{value}}</div></td>
+                </tr>
+                {{/each}}
+            </table>
+        </div>
+        {{/if}}
+    </div>
+
+    {{#if isRoll}}
+        <div class="dice-roll">
+            <div class="dice-result">
+                <div class="dice-formula">{{formula}}</div>
+                {{{tooltip}}}
+            </div>
+        </div>
+        <div class="dice-roll" style="margin-top: 0px;">
+            <div class="diceresult-apply">
+                <h4 class="dice-total diceresult-apply" style="flex-grow: 1">
+                    <span class="diceresult-total">
+                        {{{total}}}
+                    </span>
+                </h4>
+            </div>
+        </div>
+    {{/if}}
+</div>


### PR DESCRIPTION
リソース追加…魔動機術用の「弾丸」を追加
魔動機術の箇所にリソース管理可能となることで、マギテック/シューターの使用時にタブ移動の手間を軽減する。
![image](https://github.com/user-attachments/assets/554477fb-a546-495c-81de-a914a82536e6)

魔物データに対する「練技」仕様
・魔物データに対して「ステータス上昇効果」が適用された場合、該当するパラメータが上昇するように変更
　例）筋力…6ごとに打撃点1増加、筋力ボーナス…1ごとに打撃点1増加、など
・魔物データに対して「練技」を配置した場合、使用可能になるように変更
![image](https://github.com/user-attachments/assets/be78e0f2-db7d-43b4-b732-1fcc41f49b76)
![image](https://github.com/user-attachments/assets/a126b8f6-5f4c-4f35-9f36-dd3a0c0c438d)

セッション管理用アイテムの追加
・アイテムに「セッション」を追加し、セッション管理を行うためのアイテムとして追加
（将来的にキャラクターに設定、かつ、参照可能とできるように設定／※未実装機能）
・セッション結果の出力機能を付与／道中戦利品などを設定しておくことで、結果を出力
![image](https://github.com/user-attachments/assets/f1229987-de1c-445d-9e9c-cd32111c8b10)
