### PR TITLE
add target-select/change

### DIFF
--- a/css/sw25.css
+++ b/css/sw25.css
@@ -3548,3 +3548,18 @@ input[type=checkbox]:disabled + .checkbox--label:focus {
 .active-effect-sheet.active-effect-sheet .effect-change .key {
   flex: 3;
 }
+
+.chat-target {
+  text-align: right;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  line-height: 1em;
+}
+
+.chat-target .targetname {
+  font-size: 0.8em;
+  padding: 0;
+  margin: 0;
+}

--- a/module/helpers/chatbutton.mjs
+++ b/module/helpers/chatbutton.mjs
@@ -112,7 +112,36 @@ export async function chatButton(chatMessage, buttonType) {
     }
 
     await chatRoll();
+  } else if (buttonType == "target-select") {
+    const selectedTokens = await targetSelectDialog(chatMessage.flavor);
+    selectedTokens.forEach((token) => game.user.targets.add(token));
+    if (selectedTokens.length === 0) {
+      return;
+    }
+    const target = selectedTokens.map((target) => target.id);
+    const targetNames = selectedTokens
+      .map((target) => ">>> " + target.document.name)
+      .join("<br>");
+    const flags = chatMessage.flags;
+    const targetStr = `<span class="targetname">${targetNames}</span>`;
+
+    flags.sw25.target = target;
+    flags.sw25.targetName = targetNames;
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(chatMessage.content, 'text/html');
+
+    const button = doc.querySelector('button.buttonclick.chat-target[data-buttontype="target-select"]');
+    if (button) {
+        button.innerHTML = targetStr;
+    }
+
+    await chatMessage.update({
+      content: doc.body.innerHTML,
+      flags: flags,
+    });
   }
+
   async function chatRoll(targetTokens) {
     const label1 = item.system.label1;
     const label2 = item.system.label2;

--- a/templates/roll/roll-check.hbs
+++ b/templates/roll/roll-check.hbs
@@ -19,9 +19,17 @@
         {{/each}}
     </div>
 {{/if}}{{/if}}
+{{#if targetName}}
+    <button class="buttonclick chat-target" data-buttontype="target-select">
+        <span class="targetname">{{{targetName}}}</span>
+    </button>
+{{else}}
+    <button class="buttonclick chat-target" data-buttontype="target-select">
+        <i class="fa-solid fa-users-viewfinder"></i>
+    </button>
+{{/if}}
 <div class="dice-roll" data-action="expandRoll">
     {{#if flavor}}<div class="dice-flavor">{{flavor}}</div>{{/if}}
-    {{#if targetName}}<div class="dice-flavor">{{{targetName}}}</div>{{/if}}
     <div class="dice-result">
         <div class="dice-formula">{{formula}}</div>
         {{{tooltip}}}

--- a/templates/roll/roll-power.hbs
+++ b/templates/roll/roll-power.hbs
@@ -1,6 +1,14 @@
+{{#if targetName}}
+    <button class="buttonclick chat-target" data-buttontype="target-select">
+        <span class="targetname">{{{targetName}}}</span>
+    </button>
+{{else}}
+    <button class="buttonclick chat-target" data-buttontype="target-select">
+        <i class="fa-solid fa-users-viewfinder"></i>
+    </button>
+{{/if}}
 <div class="dice-roll" data-action="expandRoll">
     {{#if flavor}}<div class="dice-flavor">{{flavor}}</div>{{/if}}
-    {{#if targetName}}<div class="dice-flavor">{{{targetName}}}</div>{{/if}}
     {{#if tags}}
     <div class="element-tags">
         {{#if tags.condition}}


### PR DESCRIPTION
- チャットロール後のターゲット変更／選択機能の追加
  - 主に以下のケースを想定した機能となります
  - 『誤った敵をターゲットしたままロールしてしまった』
  - 『ロール結果を見てから身代わりになる能力を使用する』
<img width="297" height="986" alt="image" src="https://github.com/user-attachments/assets/d41ba878-f715-48b3-8dee-627a3ef4ccc8" />
<img width="290" height="501" alt="image" src="https://github.com/user-attachments/assets/6c771db3-089e-4c52-84e5-ce9f53d88f63" />
